### PR TITLE
fix(theme-default): code group accessibility

### DIFF
--- a/themes/theme-default/src/client/components/global/CodeGroup.ts
+++ b/themes/theme-default/src/client/components/global/CodeGroup.ts
@@ -128,38 +128,29 @@ export const CodeGroup = defineComponent({
       return h('div', { class: 'code-group' }, [
         h(
           'div',
-          { class: 'code-group__nav' },
-          h(
-            'ul',
-            { class: 'code-group__ul' },
-            items.map((vnode, i) => {
-              const isActive = i === activeIndex.value
-
-              return h(
-                'li',
-                { class: 'code-group__li' },
-                h(
-                  'button',
-                  {
-                    ref: (element) => {
-                      if (element) {
-                        tabRefs.value[i] = element as HTMLButtonElement
-                      }
-                    },
-                    class: {
-                      'code-group__nav-tab': true,
-                      'code-group__nav-tab-active': isActive,
-                    },
-                    ariaPressed: isActive,
-                    ariaExpanded: isActive,
-                    onClick: () => (activeIndex.value = i),
-                    onKeydown: (e) => keyboardHandler(e, i),
-                  },
-                  vnode.props.title,
-                ),
-              )
-            }),
-          ),
+          { class: 'code-group__nav', role: 'tablist' },
+          items.map((vnode, i) => {
+            const isActive = i === activeIndex.value
+            return h(
+              'button',
+              {
+                ref: (element) => {
+                  if (element) {
+                    tabRefs.value[i] = element as HTMLButtonElement
+                  }
+                },
+                class: {
+                  'code-group__nav-tab': true,
+                  'code-group__nav-tab-active': isActive,
+                },
+                role: 'tab',
+                ariaSelected: isActive,
+                onClick: () => (activeIndex.value = i),
+                onKeydown: (e) => keyboardHandler(e, i),
+              },
+              vnode.props.title,
+            )
+          }),
         ),
         items,
       ])

--- a/themes/theme-default/src/client/components/global/CodeGroupItem.vue
+++ b/themes/theme-default/src/client/components/global/CodeGroupItem.vue
@@ -20,7 +20,7 @@ defineProps({
   <div
     class="code-group-item"
     :class="{ 'code-group-item__active': active }"
-    :aria-selected="active"
+    role="tabpanel"
   >
     <slot />
   </div>

--- a/themes/theme-default/src/client/styles/code-group.scss
+++ b/themes/theme-default/src/client/styles/code-group.scss
@@ -12,14 +12,7 @@
   padding-top: 10px;
   border-top-left-radius: 6px;
   border-top-right-radius: 6px;
-  background-color: var(--code-bg-color);
-}
-
-.code-group__ul {
-  margin: auto 0;
-  padding-left: 0;
-  display: inline-flex;
-  list-style: none;
+  background-color: var(--c-code-group-tab-bg);
 }
 
 .code-group__nav-tab {
@@ -29,7 +22,7 @@
   background-color: transparent;
   font-size: 0.85em;
   line-height: 1.4;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--c-code-group-tab-title);
   font-weight: 600;
 }
 
@@ -38,11 +31,11 @@
 }
 
 .code-group__nav-tab:focus-visible {
-  outline: 1px solid rgba(255, 255, 255, 0.9);
+  outline: 1px solid var(--c-code-group-tab-outline);
 }
 
 .code-group__nav-tab-active {
-  border-bottom: var(--c-brand) 1px solid;
+  border-bottom: var(--c-code-group-tab-active-border) 1px solid;
 }
 
 @media (max-width: $MQMobileNarrow) {

--- a/themes/theme-default/src/client/styles/vars.scss
+++ b/themes/theme-default/src/client/styles/vars.scss
@@ -62,6 +62,12 @@
   --c-badge-danger: #dc2626;
   --c-badge-danger-text: var(--c-bg);
 
+  // code group colors
+  --c-code-group-tab-title: rgba(255, 255, 255, 0.9);
+  --c-code-group-tab-bg: var(--code-bg-color);
+  --c-code-group-tab-outline: var(var(--c-code-group-tab-title));
+  --c-code-group-tab-active-border: var(--c-brand);
+
   // transition vars
   --t-color: 0.3s ease;
   --t-transform: 0.3s ease;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [X] Read the [Contributing Guidelines](https://github.com/vuepress/vuepress-next/blob/main/docs/contributing.md).
- [X] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

While doing some accessibility testing on [my site](https://datagridvue.com) written in the RC release of Vuepress 2 I came across some accessibility issues with the code group and code group item components.

I have been testing with the latest version of the [axe chrome extension](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?utm_source=deque.com&utm_medium=referral&utm_campaign=axe_hero).

It reported on the code block item component that `Elements must only use supported ARIA attributes`.  
https://dequeuniversity.com/rules/axe/4.8/aria-allowed-attr?application=AxeChrome

![image](https://github.com/vuepress/vuepress-next/assets/30451189/cc3910e9-05fe-42b8-ac67-56f52c9592fd)

The code group item component renders the [`aria-selected`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute which should only be on elements with the roles `gridcell`, `cell`, `row`, or `tab`. 

Looking through the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#example) at ARIA attributes and tab roles the code group item should actually have the `tabpanel` role and the button to select the tab should have the `tab` role.

The changes in this PR were modeled after the example on MDN. Also, since the roles have requirements of being direct parent/child of each other I removed the wrapping `ul` and `li` elements and only had to slightly alter the CSS to keep the same visual result.

I also added a few color variables for some hard coded colors while I was in there.

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->

**Before**

![image](https://github.com/vuepress/vuepress-next/assets/30451189/dc04e011-dd1d-43b2-bfe8-706301ffe3e1)

**After**

![image](https://github.com/vuepress/vuepress-next/assets/30451189/0a2b5542-3ccb-4f5c-b87f-2a2d79929d59)


### Other Accessibility Issues

The only other accessibility I came across was that all of the heading anchors have `aria-hidden` attributes but are still focusable via keyboard navigation.  There was a bit of discussion around this already in the [`markdown-it-anchor` repo](https://github.com/valeriangalliat/markdown-it-anchor/issues/82) and you can address this by just using the `headerLink` render function instead of the `ariaHidden` render function since it wraps the entire header in an anchor.  I applied this change in my [site config directly](https://github.com/nruffing/data-grid-vue/commit/f18a722c804510722448a31b5466868a7c052f11#diff-318da1a121dbfecce693a1fdbc487a7538f06107c09919efaf06706b5f104c00) but I am happy to create a PR to make that the default behavior if that is desired.

![image](https://github.com/vuepress/vuepress-next/assets/30451189/0781e3ff-d8aa-4dc0-b42c-7f0188cdb1bd)
