### PR TITLE
feat(theme-default): sync anchor permalink function updates for better a11y

### DIFF
--- a/themes/theme-default/src/client/styles/layout.scss
+++ b/themes/theme-default/src/client/styles/layout.scss
@@ -126,7 +126,7 @@
 }
 
 .theme-default-content {
-  a:hover {
+  a:not(.anchor-header):hover {
     text-decoration: underline;
   }
 

--- a/themes/theme-default/src/client/styles/normalize.scss
+++ b/themes/theme-default/src/client/styles/normalize.scss
@@ -93,7 +93,8 @@ h6 {
   }
 
   &:hover .header-anchor {
-    opacity: 1;
+    color: var(--c-text-accent);
+    text-decoration: none;
   }
 }
 
@@ -125,28 +126,6 @@ h6 {
 }
 
 a {
-  &.header-anchor {
-    font-size: 0.85em;
-    float: left;
-    margin-left: -0.87em;
-    padding-right: 0.23em;
-    margin-top: 0.125em;
-    opacity: 0;
-    user-select: none;
-
-    @media print {
-      display: none;
-    }
-
-    &:hover {
-      text-decoration: none;
-    }
-
-    &:focus-visible {
-      opacity: 1;
-    }
-  }
-
   @media print {
     &[href^="http://"],
     &[href^="https://"]


### PR DESCRIPTION
…(vuepress#1363)

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [X] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [X] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New feature
- [ ] Other

### Description

The heading anchors have `aria-hidden` attributes but are still focusable via keyboard navigation.  There was a bit of discussion around this already in the [`markdown-it-anchor` repo](https://github.com/valeriangalliat/markdown-it-anchor/issues/82) and you can address this by just using the `headerLink` render function instead of the `ariaHidden` render function since it wraps the entire header in an anchor.

This PR is the `theme-default` style updates for the markup changes from [PR #1452](https://github.com/vuepress/vuepress-next/pull/1452) in `vuepress-next`.

This fixes #1363 

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->

#### Before
![Screenshot 2023-12-09 at 11 26 40 AM](https://github.com/vuepress/ecosystem/assets/30451189/65582f9a-f055-4b92-a44e-de7e143883bc)

Hover
![Screenshot 2023-12-09 at 11 26 46 AM](https://github.com/vuepress/ecosystem/assets/30451189/b43f52b3-4534-490a-8938-c8e3aa1f2028)

#### With Markup Changes but Without Style Updates
![Screenshot 2023-12-09 at 11 18 35 AM](https://github.com/vuepress/ecosystem/assets/30451189/f97dbe91-7c07-47db-8e5a-cdff1d2e8dd2)

Hover
![Screenshot 2023-12-09 at 11 18 41 AM](https://github.com/vuepress/ecosystem/assets/30451189/e706ca98-66f5-4388-bb29-c9a91c6979e0)


#### After
![Screenshot 2023-12-09 at 11 31 52 AM](https://github.com/vuepress/ecosystem/assets/30451189/7c0b6c9e-270b-4c1a-862e-a941dfffe932)

Hover
![Screenshot 2023-12-09 at 11 31 58 AM](https://github.com/vuepress/ecosystem/assets/30451189/e7ec7f73-26ff-498c-b8d0-02371801a650)
