### PR TITLE
fix(plugin-git): add the --follow parameter to the git log command

### DIFF
--- a/plugins/plugin-git/src/node/utils/getCreatedTime.ts
+++ b/plugins/plugin-git/src/node/utils/getCreatedTime.ts
@@ -9,7 +9,14 @@ export const getCreatedTime = async (
 ): Promise<number> => {
   const { stdout } = await execa(
     'git',
-    ['--no-pager', 'log', '--diff-filter=A', '--format=%at', ...filePaths],
+    [
+      '--no-pager',
+      'log',
+      '--follow',
+      '--diff-filter=A',
+      '--format=%at',
+      ...filePaths,
+    ],
     {
       cwd,
     },


### PR DESCRIPTION
### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New feature
- [ ] Other

### Description

The previous **createdTime** is imprecise, add `--follow` parameter to the `git log` command so that it *continues listing the history of a file beyond renames*