### PR TITLE
fix(plugin-blog): useBlogCategory() can't return currentItems correctly

### DIFF
--- a/plugins/plugin-blog/src/client/composables/useBlogCategory.ts
+++ b/plugins/plugin-blog/src/client/composables/useBlogCategory.ts
@@ -67,7 +67,7 @@ export const useBlogCategory = <
         })
       }
 
-      if (page.value.path === categoryMap.path)
+      if (decodeURIComponent(page.value.path) === categoryMap.path)
         result.currentItems = result.map[category].items
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Other

### Description

In plugin-blog, when the current path is URLEncoded (e.g. the path contains Chinese), useBlogCategory() will not return currentItems, decodeURIComponent() is added in the judgment so that it can correctly handle Chinese paths.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->

**Before**

**After**
