### PR TITLE
`defineXXXConfig` support `MaybeRefOrGetter` options

### DIFF
--- a/plugins/plugin-comment/src/client/components/CommentService.ts
+++ b/plugins/plugin-comment/src/client/components/CommentService.ts
@@ -22,12 +22,12 @@ export default defineComponent({
     const page = usePageData()
     const frontmatter = usePageFrontmatter<CommentPluginFrontmatter>()
 
-    const enableComment = commentOptions.comment !== false
+    const enableComment = computed(() => commentOptions.value.comment !== false)
 
     const enabled = computed(
       () =>
         frontmatter.value.comment ||
-        (enableComment && frontmatter.value.comment !== false),
+        (enableComment.value && frontmatter.value.comment !== false),
     )
 
     return (): VNode | null =>

--- a/plugins/plugin-comment/src/client/components/GiscusComment.ts
+++ b/plugins/plugin-comment/src/client/components/GiscusComment.ts
@@ -89,14 +89,14 @@ export default defineComponent({
     const giscusOptions = useGiscusOptions()
     const lang = usePageLang()
 
-    const enableGiscus = Boolean(
-      giscusOptions.repo &&
-        giscusOptions.repoId &&
-        giscusOptions.category &&
-        giscusOptions.categoryId,
+    const enableGiscus = computed(() =>
+      Boolean(
+        giscusOptions.value.repo &&
+          giscusOptions.value.repoId &&
+          giscusOptions.value.category &&
+          giscusOptions.value.categoryId,
+      ),
     )
-
-    const { repo, repoId, category, categoryId } = giscusOptions
 
     const loaded = ref(false)
 
@@ -114,21 +114,21 @@ export default defineComponent({
     const config = computed(
       () =>
         ({
-          repo,
-          repoId,
-          category,
-          categoryId,
+          repo: giscusOptions.value.repo,
+          repoId: giscusOptions.value.repoId,
+          category: giscusOptions.value.category,
+          categoryId: giscusOptions.value.categoryId,
           lang: giscusLang.value,
           theme: props.darkmode
-            ? giscusOptions.darkTheme || 'dark'
-            : giscusOptions.lightTheme || 'light',
-          mapping: giscusOptions.mapping || 'pathname',
+            ? giscusOptions.value.darkTheme || 'dark'
+            : giscusOptions.value.lightTheme || 'light',
+          mapping: giscusOptions.value.mapping || 'pathname',
           term: props.identifier,
-          inputPosition: giscusOptions.inputPosition || 'top',
+          inputPosition: giscusOptions.value.inputPosition || 'top',
           reactionsEnabled:
-            giscusOptions.reactionsEnabled === false ? '0' : '1',
-          strict: giscusOptions.strict === false ? '0' : '1',
-          loading: giscusOptions.lazyLoading === false ? 'eager' : 'lazy',
+            giscusOptions.value.reactionsEnabled === false ? '0' : '1',
+          strict: giscusOptions.value.strict === false ? '0' : '1',
+          loading: giscusOptions.value.lazyLoading === false ? 'eager' : 'lazy',
           emitMetadata: '0',
         }) as GiscusProps,
     )
@@ -139,14 +139,14 @@ export default defineComponent({
     })
 
     return (): VNode | null =>
-      enableGiscus
+      enableGiscus.value
         ? h(
             'div',
             {
               id: 'comment',
               class: [
                 'giscus-wrapper',
-                { 'input-top': giscusOptions.inputPosition !== 'bottom' },
+                { 'input-top': giscusOptions.value.inputPosition !== 'bottom' },
               ],
             },
             loaded.value ? h('giscus-widget', config.value) : h(LoadingIcon),

--- a/plugins/plugin-comment/src/client/components/TwikooComment.ts
+++ b/plugins/plugin-comment/src/client/components/TwikooComment.ts
@@ -1,5 +1,13 @@
 import type { VNode } from 'vue'
-import { defineComponent, h, nextTick, onMounted, ref, watch } from 'vue'
+import {
+  computed,
+  defineComponent,
+  h,
+  nextTick,
+  onMounted,
+  ref,
+  watch,
+} from 'vue'
 import { usePageLang } from 'vuepress/client'
 import { useTwikooOptions } from '../helpers/index.js'
 import { LoadingIcon } from './LoadingIcon.js'
@@ -23,7 +31,7 @@ export default defineComponent({
 
     const loaded = ref(false)
 
-    const enableTwikoo = Boolean(twikooOptions.envId)
+    const enableTwikoo = computed(() => Boolean(twikooOptions.value.envId))
 
     const initTwikoo = async (): Promise<void> => {
       const [{ init }] = await Promise.all([
@@ -31,7 +39,7 @@ export default defineComponent({
         new Promise<void>((resolve) => {
           setTimeout(() => {
             resolve()
-          }, twikooOptions.delay || 800)
+          }, twikooOptions.value.delay || 800)
         }),
       ])
 
@@ -42,21 +50,21 @@ export default defineComponent({
       await init({
         lang: lang.value === 'zh-CN' ? 'zh-CN' : 'en',
         path: props.identifier,
-        ...twikooOptions,
+        ...twikooOptions.value,
         el: '#twikoo-comment',
       })
     }
 
     onMounted(() => {
       watch(
-        () => props.identifier,
+        () => [props.identifier, twikooOptions.value],
         () => initTwikoo(),
         { immediate: true },
       )
     })
 
     return (): VNode | null =>
-      enableTwikoo
+      enableTwikoo.value
         ? h('div', { id: 'comment', class: 'twikoo-wrapper' }, [
             loaded.value ? null : h(LoadingIcon),
             h('div', { id: 'twikoo-comment' }),

--- a/plugins/plugin-comment/src/client/components/WalineComment.ts
+++ b/plugins/plugin-comment/src/client/components/WalineComment.ts
@@ -48,11 +48,11 @@ export default defineComponent({
     const walineLocale = useLocaleConfig(walineLocales)
 
     let abort: () => void
-    const enableWaline = Boolean(walineOptions.serverURL)
+    const enableWaline = computed(() => Boolean(walineOptions.value.serverURL))
 
     const enablePageViews = computed(() => {
-      if (!enableWaline) return false
-      const pluginConfig = walineOptions.pageview !== false
+      if (!enableWaline.value) return false
+      const pluginConfig = walineOptions.value.pageview !== false
       const pageConfig = frontmatter.value.pageview
 
       return (
@@ -67,13 +67,18 @@ export default defineComponent({
       lang: lang.value === 'zh-CN' ? 'zh-CN' : 'en',
       locale: walineLocale.value,
       dark: 'html.dark',
-      ...walineOptions,
+      ...walineOptions.value,
       path: props.identifier,
     }))
 
     onMounted(() => {
       watch(
-        () => props.identifier,
+        () => [
+          props.identifier,
+          walineOptions.value.serverURL,
+          walineOptions.value.delay,
+          enablePageViews.value,
+        ],
         () => {
           abort?.()
 
@@ -81,10 +86,10 @@ export default defineComponent({
             nextTick().then(() => {
               setTimeout(() => {
                 abort = pageviewCount({
-                  serverURL: walineOptions.serverURL,
+                  serverURL: walineOptions.value.serverURL,
                   path: props.identifier,
                 })
-              }, walineOptions.delay || 800)
+              }, walineOptions.value.delay || 800)
             })
         },
         { immediate: true },
@@ -92,7 +97,7 @@ export default defineComponent({
     })
 
     return (): VNode | null =>
-      enableWaline
+      enableWaline.value
         ? h(
             'div',
             { id: 'comment', class: 'waline-wrapper' },

--- a/plugins/plugin-comment/src/client/pageview/artalk.ts
+++ b/plugins/plugin-comment/src/client/pageview/artalk.ts
@@ -5,12 +5,12 @@ import type { UpdatePageview } from './typings.js'
 export const isSupported = true
 
 export const usePageview = (): UpdatePageview => {
-  const { server, site } = useArtalkOptions()
+  const options = useArtalkOptions()
 
   return ({ selector }) =>
     Artalk.loadCountWidget({
-      server,
-      site,
+      server: options.value.server,
+      site: options.value.site,
       ...(selector ? { countEl: selector } : {}),
     })
 }

--- a/plugins/plugin-comment/src/client/pageview/waline.ts
+++ b/plugins/plugin-comment/src/client/pageview/waline.ts
@@ -5,7 +5,8 @@ import type { UpdatePageview } from './typings.js'
 export const isSupported = true
 
 export const usePageview = (): UpdatePageview => {
-  const { serverURL } = useWalineOptions()
+  const walineOptions = useWalineOptions()
 
-  return (options) => pageviewCount({ serverURL, ...options })
+  return (options) =>
+    pageviewCount({ serverURL: walineOptions.value.serverURL, ...options })
 }

--- a/plugins/plugin-docsearch/src/client/helpers/docsearch.ts
+++ b/plugins/plugin-docsearch/src/client/helpers/docsearch.ts
@@ -1,7 +1,7 @@
 import type { DocSearchProps } from '@docsearch/react'
-import { deepAssign } from '@vuepress/helper/client'
-import type { App, ComputedRef, InjectionKey } from 'vue'
-import { computed, inject } from 'vue'
+import { deepAssign, isFunction } from '@vuepress/helper/client'
+import type { App, ComputedRef, InjectionKey, MaybeRefOrGetter, Ref } from 'vue'
+import { computed, inject, isRef, ref, watch } from 'vue'
 import { useRouteLocale } from 'vuepress/client'
 import type { DocsearchOptions } from '../../shared/index.js'
 
@@ -10,12 +10,14 @@ declare const __DOCSEARCH_OPTIONS__: DocsearchOptions
 
 const docSearchOptions: Partial<DocSearchProps> = __DOCSEARCH_OPTIONS__
 
-let docsearch: Partial<DocSearchProps> = docSearchOptions
+const docsearch: Ref<Partial<DocSearchProps>> = ref(docSearchOptions)
 
 const docsearchSymbol: InjectionKey<
-  DocSearchProps & {
-    locales?: Record<string, DocSearchProps>
-  }
+  Ref<
+    DocSearchProps & {
+      locales?: Record<string, DocSearchProps>
+    }
+  >
 > = Symbol(__VUEPRESS_DEV__ ? 'docsearch' : '')
 
 export type DocSearchClientLocaleOptions = Partial<
@@ -27,9 +29,22 @@ export interface DocSearchClientOptions extends DocSearchClientLocaleOptions {
 }
 
 export const defineDocSearchConfig = (
-  options: DocSearchClientOptions,
+  options: MaybeRefOrGetter<DocSearchClientOptions>,
 ): void => {
-  docsearch = deepAssign({}, docSearchOptions, options)
+  if (isRef(options)) {
+    watch(
+      () => options.value,
+      (value) => {
+        docsearch.value = deepAssign({}, docSearchOptions, value)
+      },
+    )
+  } else if (isFunction(options)) {
+    watch(options, (value) => {
+      docsearch.value = deepAssign({}, docSearchOptions, value)
+    })
+  } else {
+    docsearch.value = deepAssign({}, docSearchOptions, options)
+  }
 }
 
 export const useDocSearchOptions = (): ComputedRef<DocSearchProps> => {
@@ -37,8 +52,8 @@ export const useDocSearchOptions = (): ComputedRef<DocSearchProps> => {
   const routeLocale = useRouteLocale()
 
   return computed(() => ({
-    ...options,
-    ...options.locales?.[routeLocale.value],
+    ...options.value,
+    ...options.value.locales?.[routeLocale.value],
   }))
 }
 

--- a/plugins/plugin-photo-swipe/src/client/composables/usePhotoSwipe.ts
+++ b/plugins/plugin-photo-swipe/src/client/composables/usePhotoSwipe.ts
@@ -45,7 +45,7 @@ export const usePhotoSwipe = ({
           destroy = await registerPhotoSwipe(
             getImages(imageSelector),
             {
-              ...photoSwipeOptions,
+              ...photoSwipeOptions.value,
               ...locale.value,
             },
             scrollToClose,
@@ -57,7 +57,7 @@ export const usePhotoSwipe = ({
     setupPhotoSwipe()
 
     watch(
-      () => page.value.path,
+      () => [page.value.path, photoSwipeOptions.value],
       () => {
         destroy?.()
         setupPhotoSwipe()

--- a/plugins/plugin-photo-swipe/src/client/helpers/photo-swipe.ts
+++ b/plugins/plugin-photo-swipe/src/client/helpers/photo-swipe.ts
@@ -1,6 +1,7 @@
+import { isFunction } from '@vuepress/helper/client'
 import type { PhotoSwipeOptions as OriginalPhotoSwipeOptions } from 'photoswipe'
-import type { App } from 'vue'
-import { inject } from 'vue'
+import type { App, MaybeRefOrGetter, Ref } from 'vue'
+import { inject, isRef, ref, watch } from 'vue'
 
 export type PhotoSwipeOptions = Omit<
   OriginalPhotoSwipeOptions,
@@ -10,15 +11,30 @@ export type PhotoSwipeOptions = Omit<
 
 declare const __VUEPRESS_DEV__: boolean
 
-let photoswipeOptions: PhotoSwipeOptions = {}
+const photoswipeOptions: Ref<PhotoSwipeOptions> = ref({})
 
 const photoswipeSymbol = Symbol(__VUEPRESS_DEV__ ? 'photoswipe' : '')
 
-export const definePhotoSwipeConfig = (options: PhotoSwipeOptions): void => {
-  photoswipeOptions = options
+export const definePhotoSwipeConfig = (
+  options: MaybeRefOrGetter<PhotoSwipeOptions>,
+): void => {
+  if (isRef(options)) {
+    watch(
+      () => options.value,
+      (value) => {
+        photoswipeOptions.value = value
+      },
+    )
+  } else if (isFunction(options)) {
+    watch(options, (value) => {
+      photoswipeOptions.value = value
+    })
+  } else {
+    photoswipeOptions.value = options
+  }
 }
 
-export const usePhotoSwipeOptions = (): PhotoSwipeOptions =>
+export const usePhotoSwipeOptions = (): Ref<PhotoSwipeOptions> =>
   inject(photoswipeSymbol)!
 
 export const injectPhotoSwipeConfig = (app: App): void => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New feature
- [ ] Other

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

#111 

Adjust the `defineXXXConfig(options)` function parameters exported by some plugins, updating the type of the `options` parameter to `MaybeRefOrGetter<XXX>`. This allows third parties to have more flexibility in controlling the behavior of the plugins when using them.

**plugin-photo-swipe**：
 
```diff
- export const definePhotoSwipeConfig = (options: PhotoSwipeOptions)
+ export const definePhotoSwipeConfig = (options: MaybeRefOrGetter<PhotoSwipeOptions>)
```

**plugin-docsearch**

```diff
- export const defineDocSearchConfig = (options: DocSearchClientOptions)
+ export const defineDocSearchConfig = (options: MaybeRefOrGetter<DocSearchClientOptions>)
```

**plugin-comment**

I'm not sure if it's necessary to modify the 'defineXXXConfig' exported by the comment plugin, so I haven't made any changes to them.
