### PR TITLE
fix(theme-default): code block line number misalignment in Safari

### DIFF
--- a/themes/theme-default/src/client/styles/code.scss
+++ b/themes/theme-default/src/client/styles/code.scss
@@ -235,7 +235,6 @@ div[class*='language-'] {
         position: relative;
         z-index: 3;
         user-select: none;
-        height: #{$line-height}em;
 
         &::before {
           counter-increment: line-number;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Other

### Description

The height of `.line-number` should be calculated based on the `font-size` and `line-height` of `.line-numbers`, rather than being directly set to `{line-height}em`, as this could lead to rendering issues.

```diff
 .line-number {
   ...
-  height: #{$line-height}em;
 }
```
