### PR TITLE
chore(plugin-shiki): improve shiki logger

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,6 +46,7 @@
     "preload",
     "prismjs",
     "shiki",
+    "shikijs",
     "slugify",
     "tsbuildinfo",
     "twikoo",

--- a/plugins/markdown/plugin-shiki/package.json
+++ b/plugins/markdown/plugin-shiki/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@shikijs/transformers": "^1.6.1",
+    "@vuepress/helper": "workspace:~",
     "nanoid": "^5.0.7",
     "shiki": "^1.6.1"
   },

--- a/plugins/markdown/plugin-shiki/src/node/resolveHighlight.ts
+++ b/plugins/markdown/plugin-shiki/src/node/resolveHighlight.ts
@@ -1,9 +1,9 @@
 import { transformerCompactLineOptions } from '@shikijs/transformers'
 import { bundledLanguages, getHighlighter, isSpecialLang } from 'shiki'
-import { colors, logger } from 'vuepress/utils'
+import { colors } from 'vuepress/utils'
 import { getTransformers } from './transformers/getTransformers.js'
 import type { ShikiHighlightOptions } from './types.js'
-import { attrsToLines, nanoid, resolveLanguage } from './utils.js'
+import { attrsToLines, logger, nanoid, resolveLanguage } from './utils.js'
 
 export { bundledLanguages } from 'shiki'
 export const bundledLanguageNames = Object.keys(bundledLanguages)
@@ -35,9 +35,7 @@ export const resolveHighlight = async ({
 
     if (lang && !loadedLanguages.includes(lang) && !isSpecialLang(lang)) {
       logger.warn(
-        colors.yellow(
-          `\nThe language '${lang}' is not loaded, falling back to '${defaultHighlightLang || 'txt'}' for syntax highlighting.`,
-        ),
+        `${colors.cyan(lang)}' is not loaded! Using '${colors.cyan(defaultHighlightLang || 'txt')}' to highlight instead.`,
       )
       lang = defaultHighlightLang
     }

--- a/plugins/markdown/plugin-shiki/src/node/utils.ts
+++ b/plugins/markdown/plugin-shiki/src/node/utils.ts
@@ -1,7 +1,12 @@
 import type { TransformerCompactLineOption } from '@shikijs/transformers'
+import { Logger } from '@vuepress/helper'
 import { customAlphabet } from 'nanoid'
 
 const VUE_RE = /-vue$/
+
+export const PLUGIN_NAME = '@vuepress/plugin-shiki'
+
+export const logger = new Logger(PLUGIN_NAME)
 
 export const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 10)
 

--- a/plugins/markdown/plugin-shiki/tsconfig.build.json
+++ b/plugins/markdown/plugin-shiki/tsconfig.build.json
@@ -4,5 +4,6 @@
     "rootDir": "./src",
     "outDir": "./lib"
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "references": [{ "path": "../../../tools/helper/tsconfig.build.json" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,6 +686,9 @@ importers:
       '@shikijs/transformers':
         specifier: ^1.6.1
         version: 1.6.1
+      '@vuepress/helper':
+        specifier: workspace:~
+        version: link:../../../tools/helper
       nanoid:
         specifier: ^5.0.7
         version: 5.0.7


### PR DESCRIPTION
The original warnings does not have source, and a bit ugly:

![image](https://github.com/vuepress/ecosystem/assets/33315834/7f3ebce5-45b4-4f47-b465-103471543dd2)
