### PR TITLE
feat(plugin-shiki)!: remove defaultColor option and improve types

### DIFF
--- a/docs/plugins/markdown/shiki.md
+++ b/docs/plugins/markdown/shiki.md
@@ -50,13 +50,16 @@ export default {
 - Also see:
   - [Shiki > Languages](https://shiki.style/languages)
 
-### defaultHighlightLang
+### langAlias
 
-- Type: `string`
+- Type: `{ [lang: string]: string }`
 
 - Details:
 
-  Fallback language when the specified language is not available.
+  Customize language aliases for Shiki.
+
+- 参考：
+  - [Shiki > Custom Language Aliases](https://shiki.style/guide/load-lang#custom-language-aliases)
 
 ### theme
 
@@ -64,9 +67,7 @@ export default {
 
 - Default: `'nord'`
 
-- Details:
-
-  Theme of Shiki, will be default applied to code block.
+- Details: Theme of Shiki, will be applied to code blocks.
 
 - Also see:
   - [Shiki > Themes](https://shiki.style/themes)
@@ -88,19 +89,6 @@ export default {
 - Also see:
   - [Shiki > Dual Themes](https://shiki.style/guide/dual-themes)
 
-### transformers
-
-- Type: `ShikiTransformer[]`
-
-- Details:
-
-  Transformers of Shiki.
-
-  This option will be forwarded to `codeToHtml()` method of Shiki.
-
-- Also see:
-  - [Shiki > Transformers](https://shiki.style/guide/transformers)
-
 ### lineNumbers
 
 - Type: `boolean | number`
@@ -109,16 +97,12 @@ export default {
 
 - Details:
 
-  Configure code line numbers.
-
   - `true`: enable line numbers.
   - `false`: disabled line numbers.
   - `number`: the minimum number of lines to enable line numbers.
     For example, if you set it to 4, line numbers will only be enabled when your code block has at least 4 lines of code.
 
-  You can add `:line-numbers` / `:no-line-numbers` mark in your fenced code blocks to override the value set in config.
-
-  You can also customize the starting line number by adding `=` after `:line-numbers`. For example, `:line-numbers=2` means the line numbers in code blocks will start from `2`.
+  You can add `:line-numbers` / `:no-line-numbers` mark in your fenced code blocks to override the value set in config, and customize the beginning number by adding `=` after `:line-numbers`. For example, `:line-numbers=2` means the line numbers in code blocks will start from `2`.
 
 **Input:**
 
@@ -129,13 +113,13 @@ const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
-```ts:no-line-numbers
+```ts :no-line-numbers
 // line-numbers is disabled
 const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
-```ts:line-numbers=2
+```ts :line-numbers=2
 // line-numbers is enabled and start from 2
 const line3 = 'This is line 3'
 const line4 = 'This is line 4'
@@ -144,19 +128,19 @@ const line4 = 'This is line 4'
 
 **Output:**
 
-```ts:line-numbers
+```ts :line-numbers
 // line-numbers is enabled
 const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
-```ts:no-line-numbers
+```ts :no-line-numbers
 // line-numbers is disabled
 const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
-```ts:line-numbers=2
+```ts :line-numbers=2
 // line-numbers is enabled and start from 2
 const line3 = 'This is line 3'
 const line4 = 'This is line 4'
@@ -170,11 +154,7 @@ const line4 = 'This is line 4'
 
 - Details:
 
-  Whether enable code line highlighting.
-
-  You can highlight specified lines of your code blocks by adding line ranges mark in your fenced code blocks.
-
-  Examples for line ranges mark:
+  Whether enable code line highlighting. You can highlight specified lines of your code blocks by adding line ranges mark in your fenced code blocks:
 
   - Line ranges: `{5-8}`
   - Multiple single lines: `{4,7,9}`
@@ -183,7 +163,7 @@ const line4 = 'This is line 4'
 **Input:**
 
 ````md
-```ts{1,7-9}
+```ts {1,7-9}
 import { defaultTheme } from '@vuepress/theme-default'
 import { defineUserConfig } from 'vuepress'
 
@@ -199,7 +179,7 @@ export default defineUserConfig({
 
 **Output:**
 
-```ts{1,7-9}
+```ts {1,7-9}
 import { defaultTheme } from '@vuepress/theme-default'
 import { defineUserConfig } from 'vuepress'
 
@@ -211,26 +191,6 @@ export default defineUserConfig({
   }),
 })
 ```
-
-### preWrapper
-
-- Type: `boolean`
-
-- Default: `true`
-
-- Details:
-
-  Enable the extra wrapper of the `<pre>` tag or not.
-
-  The wrapper is required by the `lineNumbers`. That means, if you disable `preWrapper`, the line line numbers will also be disabled.
-
-### shikiSetup
-
-- Type: `(shiki: Highlighter) => void | Promise<void>`
-
-- Details:
-
-  Function to customize Shiki highlighter instance.
 
 :::: tip
 
@@ -248,9 +208,7 @@ The following features requires additional style to work, which should be handle
 
 - Default: `false`
 
-- Details:
-
-  Whether enable notation diff
+- Details: Whether enable notation diff.
 
 - Example:
 
@@ -269,9 +227,7 @@ The following features requires additional style to work, which should be handle
 
 - Default: `false`
 
-- Details:
-
-  Whether enable notation focus.
+- Details: Whether enable notation focus.
 
 - Example:
 
@@ -290,9 +246,7 @@ The following features requires additional style to work, which should be handle
 
 - Default: `false`
 
-- Details:
-
-  Whether enable notation highlight.
+- Details: Whether enable notation highlight.
 
 - Example:
 
@@ -311,9 +265,7 @@ The following features requires additional style to work, which should be handle
 
 - Default: `false`
 
-- Details:
-
-  Whether enable notation error level.
+- Details: Whether enable notation error level.
 
 - Example:
 
@@ -325,3 +277,44 @@ The following features requires additional style to work, which should be handle
 
 - Also see:
   - [Shiki > Notation Error Level](https://shiki.style/packages/transformers#transformernotationerrorlevel)
+
+## Advanced Options
+
+### defaultLang
+
+- Type: `string`
+
+- Default: `'plain'`
+
+- Details: Fallback language when the specified language is not available.
+
+### preWrapper
+
+- Type: `boolean`
+
+- Default: `true`
+
+- Details:
+
+  Adds extra wrapper outside `<pre>` tag or not.
+
+  The wrapper is required by the `lineNumbers`. That means, if you disable `preWrapper`, the line line numbers will also be disabled.
+
+### shikiSetup
+
+- Type: `(shiki: Highlighter) => void | Promise<void>`
+
+- Details: A function hook to customize Shiki highlighter instance.
+
+### transformers
+
+- Type: `ShikiTransformer[]`
+
+- Details:
+
+  Transformers of Shiki.
+
+  This option will be forwarded to `codeToHtml()` method of Shiki.
+
+- Also see:
+  - [Shiki > Transformers](https://shiki.style/guide/transformers)

--- a/docs/plugins/markdown/shiki.md
+++ b/docs/plugins/markdown/shiki.md
@@ -41,7 +41,11 @@ export default {
 
   This option will be forwarded to `getHighlighter()` method of Shiki.
 
-  You'd better provide the languages list you are using explicitly, otherwise Shiki will load all languages and can affect performance.
+  ::: warning
+
+  We recommend you to provide the languages list you are using explicitly, otherwise Shiki will load all languages and can affect performance.
+
+  :::
 
 - Also see:
   - [Shiki > Languages](https://shiki.style/languages)
@@ -62,22 +66,24 @@ export default {
 
 - Details:
 
-  Theme of Shiki.
-
-  This option will be forwarded to `codeToHtml()` method of Shiki.
+  Theme of Shiki, will be default applied to code block.
 
 - Also see:
   - [Shiki > Themes](https://shiki.style/themes)
 
 ### themes
 
-- Type: `Record<'dark' | 'light', ShikiTheme>`
+- Type: `{ light: ShikiTheme; dark: ShikiTheme }`
 
 - Details:
 
   Dark / Light Dual themes of Shiki.
 
-  This option will be forwarded to `codeToHtml()` method of Shiki.
+  The styles of the 2 themes will be injected as `--shiki-light` and `--shiki-dark` to code blocks:
+
+  ```html
+  <span style="--shiki-light:lightColor;--shiki-dark:darkColor;">code</span>
+  ```
 
 - Also see:
   - [Shiki > Dual Themes](https://shiki.style/guide/dual-themes)
@@ -217,33 +223,6 @@ export default defineUserConfig({
   Enable the extra wrapper of the `<pre>` tag or not.
 
   The wrapper is required by the `lineNumbers`. That means, if you disable `preWrapper`, the line line numbers will also be disabled.
-
-### defaultColor
-
-- Type: `false | 'light' | 'dark' | string`
-
-- Default: `'light'`
-
-- Details:
-
-  The default theme applied to the code (via inline `color` style). The rest of the themes are applied via CSS variables, and toggled by CSS overrides.
-
-  For example, if `defaultColor` is `light`, then `light` theme is applied to the code, and the `dark` theme and other custom themes are applied via CSS variables:
-
-```html
-<span style="color:#{light};--shiki-dark:#{dark};--shiki-custom:#{custom};"
-  >code</span
->
-```
-
-When set to `false`, no default styles will be applied, and totally up to users to apply the styles:
-
-```html
-<span
-  style="--shiki-light:#{light};--shiki-dark:#{dark};--shiki-custom:#{custom};"
-  >code</span
->
-```
 
 ### shikiSetup
 

--- a/docs/zh/plugins/markdown/shiki.md
+++ b/docs/zh/plugins/markdown/shiki.md
@@ -41,7 +41,11 @@ export default {
 
   该配置项会被传递到 Shiki 的 `getHighlighter()` 方法中。
 
-  你最好明确传入所有你使用的语言列表，否则 Shiki 会加载所有语言，并可能影响性能。
+  ::: warning
+
+  我们建议明确传入所有你使用的语言列表，否则 Shiki 会加载所有语言，并可能影响性能。
+
+  :::
 
 - 参考：
   - [shiki > Languages](https://shiki.style/languages)
@@ -52,7 +56,7 @@ export default {
 
 - 详情：
 
-  当指定的语言不可用时，使用备选语言。
+  当指定的语言不可用时所使用的备选语言。
 
 ### theme
 
@@ -62,22 +66,24 @@ export default {
 
 - 详情：
 
-  Shiki 的主题。
-
-  该配置项会被传递到 Shiki 的 `codeToHtml()` 方法中。
+  Shiki 的主题。该主题会默认应用到代码块上。
 
 - 参考：
   - [Shiki > Themes](https://shiki.style/themes)
 
 ### themes
 
-- 类型：`Record<'dark' | 'light', ShikiTheme>`
+- 类型：`{ light: ShikiTheme; dark: ShikiTheme }`
 
 - 详情：
 
   Shiki 的暗黑和明亮模式双主题。
 
-  该配置项会被传递到 Shiki 的 `codeToHtml()` 方法中。
+  两个主题的样式会分别通过 `--shiki-light` 和 `--shiki-dark` 注入到代码块上：
+
+  ```html
+  <span style="--shiki-light:lightColor;--shiki-dark:darkColor;">code</span>
+  ```
 
 - 参考：
   - [Shiki > Dual Themes](https://shiki.style/guide/dual-themes)
@@ -216,33 +222,6 @@ export default defineUserConfig({
   是否在 `<pre>` 标签外额外包裹一层。
 
   `lineNumbers` 依赖于这个额外的包裹层。这换句话说，如果你禁用了 `preWrapper` ，那么 行号 也会被同时禁用。
-
-### defaultColor
-
-- 类型： `false | 'light' | 'dark' | string`
-
-- 默认值： `'light'`
-
-- 详情：
-
-  应用于代码的默认主题（通过内联 `color` 样式）。其余主题通过 CSS 变量应用，并通过 CSS 覆盖进行切换。
-
-  例如，如果 `defaultColor` 是 `light`，则将 `light` 主题应用于代码，并通过 CSS 变量应用 `dark` 主题和其他自定义主题：
-
-```html
-<span style="color:#{light};--shiki-dark:#{dark};--shiki-custom:#{custom};"
-  >code</span
->
-```
-
-设置为 `false` 时，将不会应用任何默认样式，完全由用户自行应用样式。
-
-```html
-<span
-  style="--shiki-light:#{light};--shiki-dark:#{dark};--shiki-custom:#{custom};"
-  >code</span
->
-```
 
 ### shikiSetup
 

--- a/docs/zh/plugins/markdown/shiki.md
+++ b/docs/zh/plugins/markdown/shiki.md
@@ -2,11 +2,11 @@
 
 <NpmBadge package="@vuepress/plugin-shiki" />
 
-该插件使用 [Shiki](https://shiki.style/) 来为 Markdown 代码块启用代码高亮。
+该插件使用 [Shiki](https://shiki.tmrs.site/) 来为 Markdown 代码块启用代码高亮。
 
 ::: tip
 
-[Shiki](https://shiki.style/) 是 VSCode 正在使用的代码高亮器。它具有更高的保真度，但可能会比 [Prism.js](https://prismjs.com/) 要慢一些，特别是在有大量代码块需要处理的时候。
+[Shiki](https://shiki.tmrs.site/) 是 VSCode 正在使用的代码高亮器。它具有更高的保真度，但可能会比 [Prism.js](https://prismjs.com/) 要慢一些，特别是在有大量代码块需要处理的时候。
 
 :::
 
@@ -33,7 +33,7 @@ export default {
 
 ### langs
 
-- 类型： `ShikiLang[]`
+- 类型：`ShikiLang[]`
 
 - 详情：
 
@@ -48,28 +48,29 @@ export default {
   :::
 
 - 参考：
-  - [shiki > Languages](https://shiki.style/languages)
+  - [Shiki > 语言](https://shiki.tmrs.site/languages)
 
-### defaultHighlightLang
+### langAlias
 
-- 类型： `string`
+- 类型：`{ [lang: string]: string }`
 
 - 详情：
 
-  当指定的语言不可用时所使用的备选语言。
+  自定义 Shiki 语言别名。
+
+- 参考：
+  - [Shiki > 自定义语言别名](https://shiki.tmrs.site/guide/load-lang#custom-language-aliases)
 
 ### theme
 
-- 类型： `ShikiTheme`
+- 类型：`ShikiTheme`
 
-- 默认值： `'nord'`
+- 默认值：`'nord'`
 
-- 详情：
-
-  Shiki 的主题。该主题会默认应用到代码块上。
+- 详情：Shiki 的主题。该主题会应用到代码块上。
 
 - 参考：
-  - [Shiki > Themes](https://shiki.style/themes)
+  - [Shiki > 主题](https://shiki.tmrs.site/themes)
 
 ### themes
 
@@ -86,55 +87,39 @@ export default {
   ```
 
 - 参考：
-  - [Shiki > Dual Themes](https://shiki.style/guide/dual-themes)
-
-### transformers
-
-- 类型：`ShikiTransformer[]`
-- 详情：
-
-  Shiki 的转换器。
-
-  该配置项会被传递到 Shiki 的 `codeToHtml()` 方法中。
-
-- 参考：
-  - [Shiki > Transformers](https://shiki.style/guide/transformers)
+  - [Shiki > Dual Themes](https://shiki.tmrs.site/guide/dual-themes)
 
 ### lineNumbers
 
-- 类型： `boolean | number`
+- 类型：`boolean | number`
 
-- 默认值： `true`
+- 默认值：`true`
 
 - 详情：
-
-  是否启用行号。
 
   - `true`：启用代码行号
   - `false`：禁用代码行号。
   - `number`：显示行号所需的最少行数。
     例如，如果你将它设置为 4 ，那么只有在你的代码块包含至少 4 行代码时才会启用行号。
 
-  你可以在代码块添加 `:line-numbers` / `:no-line-numbers` 标记来覆盖配置项中的设置。
-
-  还可以通过在 `:line-numbers` 之后添加 `=` 来自定义起始行号，例如 `:line-numbers=2` 表示代码块中的行号从 `2` 开始。
+  你可以在代码块添加 `:line-numbers` / `:no-line-numbers` 标记来覆盖配置项中的设置，还可以在 `:line-numbers` 之后添加 `=` 来自定义起始行号，例如 `:line-numbers=2` 表示代码块中的行号从 `2` 开始。
 
 **输入：**
 
 ````md
-```ts:line-numbers
+```ts :line-numbers
 // 启用行号
 const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
-```ts:no-line-numbers
+```ts :no-line-numbers
 // 禁用行号
 const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
-```ts:line-numbers=2
+```ts :line-numbers=2
 // 行号已启用，并从 2 开始
 const line3 = 'This is line 3'
 const line4 = 'This is line 4'
@@ -143,19 +128,19 @@ const line4 = 'This is line 4'
 
 **输出：**
 
-```ts:line-numbers
+```ts :line-numbers
 // 启用行号
 const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
-```ts:no-line-numbers
+```ts :no-line-numbers
 // 禁用行号
 const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
-```ts:line-numbers=2
+```ts :line-numbers=2
 // 行号已启用，并从 2 开始
 const line3 = 'This is line 3'
 const line4 = 'This is line 4'
@@ -163,26 +148,22 @@ const line4 = 'This is line 4'
 
 ### highlightLines
 
-- 类型： `boolean`
+- 类型：`boolean`
 
-- 默认值： `true`
+- 默认值：`true`
 
 - 详情：
 
-  是否启用 行高亮。
+  是否启用行高亮。启用后，可在代码块的信息描述中添加行数标记来高亮指定的行：
 
-  在代码块添加行数范围标记，来为对应代码行进行高亮。
-
-  行数范围标记的例子：
-
-  - 行数范围： `{5-8}`
-  - 多个单行： `{4,7,9}`
-  - 组合： `{4,7-13,16,23-27,40}`
+  - 行数范围：`{5-8}`
+  - 多个单行：`{4,7,9}`
+  - 组合：`{4,7-13,16,23-27,40}`
 
 **输入：**
 
 ````md
-```ts{1,7-9}
+```ts {1,7-9}
 import { defaultTheme } from '@vuepress/theme-default'
 import { defineUserConfig } from 'vuepress'
 
@@ -198,7 +179,7 @@ export default defineUserConfig({
 
 **输出：**
 
-```ts{1,7-9}
+```ts {1,7-9}
 import { defaultTheme } from '@vuepress/theme-default'
 import { defineUserConfig } from 'vuepress'
 
@@ -210,26 +191,6 @@ export default defineUserConfig({
   }),
 })
 ```
-
-### preWrapper
-
-- 类型： `boolean`
-
-- 默认值： `true`
-
-- 详情：
-
-  是否在 `<pre>` 标签外额外包裹一层。
-
-  `lineNumbers` 依赖于这个额外的包裹层。这换句话说，如果你禁用了 `preWrapper` ，那么 行号 也会被同时禁用。
-
-### shikiSetup
-
-- 类型： `(shiki: Highlighter) => void | Promise<void>`
-
-- 详情：
-
-  自定义 Shiki 函数。您可以通过在配置中添加自己的 shikiSetup 函数来扩展 Shiki 实例。
 
 :::: tip
 
@@ -243,13 +204,11 @@ export default defineUserConfig({
 
 ### notationDiff
 
-- 类型： `boolean`
+- 类型：`boolean`
 
-- 默认值： `false`
+- 默认值：`false`
 
-- 详情：
-
-  是否启用 Notation Diff
+- 详情：是否启用差异标记。
 
 - 示例：
 
@@ -260,17 +219,15 @@ export default defineUserConfig({
   ```
 
 - 参考：
-  - [Shiki > Notation Diff](https://shiki.style/packages/transformers#transformernotationdiff)
+  - [Shiki > 差异标记](https://shiki.tmrs.site/packages/transformers#transformernotationdiff)
 
 ### notationFocus
 
-- 类型： `boolean`
+- 类型：`boolean`
 
-- 默认值： `false`
+- 默认值：`false`
 
-- 详情：
-
-  是否启用 Notation Focus.
+- 详情：是否启用聚焦标记。
 
 - 示例：
 
@@ -281,17 +238,15 @@ export default defineUserConfig({
   ```
 
 - 参考：
-  - [Shiki > Notation Focus](https://shiki.style/packages/transformers#transformernotationfocus)
+  - [Shiki > 聚焦标记](https://shiki.tmrs.site/packages/transformers#transformernotationfocus)
 
 ### notationHighlight
 
-- 类型： `boolean`
+- 类型：`boolean`
 
-- 默认值： `false`
+- 默认值：`false`
 
-- 详情：
-
-  是否启用 Notation Highlight.
+- 详情：是否启用高亮标记。
 
 - 示例：
 
@@ -302,17 +257,15 @@ export default defineUserConfig({
   ```
 
 - 参考：
-  - [Shiki > Notation Highlight](https://shiki.style/packages/transformers#transformernotationhighlight)
+  - [Shiki > 高亮标记](https://shiki.tmrs.site/packages/transformers#transformernotationhighlight)
 
 ### notationErrorLevel
 
-- 类型： `boolean`
+- 类型：`boolean`
 
-- 默认值： `false`
+- 默认值：`false`
 
-- 详情：
-
-  是否启用 Notation Error Level.
+- 详情：是否启用错误级别标记。
 
 - 示例：
 
@@ -323,4 +276,45 @@ export default defineUserConfig({
   ```
 
 - 参考：
-  - [Shiki > Notation Error Level](https://shiki.style/packages/transformers#transformernotationerrorlevel)
+  - [Shiki > 错误级别标记](https://shiki.tmrs.site/packages/transformers#transformernotationerrorlevel)
+
+## 高级选项
+
+### defaultLang
+
+- 类型：`string`
+
+- 默认值：`'plain'`
+
+- 详情：指定的语言不可用时所使用的备选语言。
+
+### preWrapper
+
+- 类型：`boolean`
+
+- 默认值：`true`
+
+- 详情：
+
+  是否在 `<pre>` 标签外添加包裹容器。
+
+  `lineNumbers` 依赖于这个额外的包裹层。这换句话说，如果你禁用了 `preWrapper` ，那么行号也会被同时禁用。
+
+### shikiSetup
+
+- 类型：`(shiki: Highlighter) => void | Promise<void>`
+
+- 详情： 一个用于自定义 Shiki 高亮器的钩子函数。
+
+### transformers
+
+- 类型：`ShikiTransformer[]`
+
+- 详情：
+
+  添加 Shiki 转换器。
+
+  该配置项会被传递到 Shiki 的 `codeToHtml()` 方法中。
+
+- 参考：
+  - [Shiki > 转换器](https://shiki.tmrs.site/guide/transformers)

--- a/plugins/markdown/plugin-shiki/src/node/resolveHighlight.ts
+++ b/plugins/markdown/plugin-shiki/src/node/resolveHighlight.ts
@@ -12,8 +12,7 @@ const MUSTACHE_REG = /\{\{[^]*?\}\}/g
 
 export const resolveHighlight = async ({
   langs = bundledLanguageNames,
-  theme = 'nord',
-  themes,
+  langAlias = {},
   defaultHighlightLang = '',
   transformers: userTransformers = [],
   ...options
@@ -22,7 +21,11 @@ export const resolveHighlight = async ({
 > => {
   const highlighter = await getHighlighter({
     langs,
-    themes: themes ? [themes.dark, themes.light] : [theme],
+    langAlias,
+    themes:
+      'themes' in options
+        ? [options.themes.dark, options.themes.light]
+        : [options.theme ?? 'nord'],
   })
 
   await options.shikiSetup?.(highlighter)
@@ -80,7 +83,12 @@ export const resolveHighlight = async ({
           : []),
         ...userTransformers,
       ],
-      ...(themes ? { themes, defaultColor: options.defaultColor } : { theme }),
+      ...('themes' in options
+        ? {
+            themes: options.themes,
+            defaultColor: false,
+          }
+        : { theme: options.theme ?? 'nord' }),
     })
 
     return restoreMustache(highlighted)

--- a/plugins/markdown/plugin-shiki/src/node/resolveHighlight.ts
+++ b/plugins/markdown/plugin-shiki/src/node/resolveHighlight.ts
@@ -13,7 +13,7 @@ const MUSTACHE_REG = /\{\{[^]*?\}\}/g
 export const resolveHighlight = async ({
   langs = bundledLanguageNames,
   langAlias = {},
-  defaultHighlightLang = '',
+  defaultLang = '',
   transformers: userTransformers = [],
   ...options
 }: ShikiHighlightOptions = {}): Promise<
@@ -38,9 +38,9 @@ export const resolveHighlight = async ({
 
     if (lang && !loadedLanguages.includes(lang) && !isSpecialLang(lang)) {
       logger.warn(
-        `${colors.cyan(lang)}' is not loaded! Using '${colors.cyan(defaultHighlightLang || 'txt')}' to highlight instead.`,
+        `${colors.cyan(lang)}' is not loaded! Using '${colors.cyan(defaultLang || 'plain')}' to highlight instead.`,
       )
-      lang = defaultHighlightLang
+      lang = defaultLang
     }
 
     const codeMustaches = new Map<string, string>()

--- a/plugins/markdown/plugin-shiki/src/node/types.ts
+++ b/plugins/markdown/plugin-shiki/src/node/types.ts
@@ -61,8 +61,10 @@ export type ShikiHighlightOptions = ShikiThemeOptions & {
 
   /**
    * Fallback language when the specified language is not available.
+   *
+   * @default 'plain'
    */
-  defaultHighlightLang?: string
+  defaultLang?: string
 
   /**
    * Function to customize Shiki highlighter instance.

--- a/plugins/markdown/plugin-shiki/src/node/types.ts
+++ b/plugins/markdown/plugin-shiki/src/node/types.ts
@@ -6,8 +6,7 @@ import type {
   ShikiTransformer,
   SpecialLanguage,
   StringLiteralUnion,
-  ThemeRegistration,
-  ThemeRegistrationRaw,
+  ThemeRegistrationAny,
 } from 'shiki'
 
 export type ShikiLang =
@@ -15,12 +14,34 @@ export type ShikiLang =
   | StringLiteralUnion<BundledLanguage>
   | SpecialLanguage
 
-export type ShikiTheme =
-  | ThemeRegistration
-  | ThemeRegistrationRaw
-  | StringLiteralUnion<BundledTheme>
+export type ShikiTheme = ThemeRegistrationAny | StringLiteralUnion<BundledTheme>
 
-export interface ShikiHighlightOptions {
+export interface ShikiSingleThemeOptions {
+  /**
+   * The single theme to use
+   *
+   * @see https://shiki.style/themes
+   *
+   * @default 'nord'
+   */
+  theme?: ShikiTheme
+}
+
+export interface ShikiDualThemeOptions {
+  /**
+   * The dark and light themes to use
+   *
+   * @see https://shiki.style/themes
+   */
+  themes: {
+    dark: ShikiTheme
+    light: ShikiTheme
+  }
+}
+
+export type ShikiThemeOptions = ShikiDualThemeOptions | ShikiSingleThemeOptions
+
+export type ShikiHighlightOptions = ShikiThemeOptions & {
   /**
    * Languages to be loaded.
    *
@@ -32,39 +53,26 @@ export interface ShikiHighlightOptions {
   langs?: ShikiLang[]
 
   /**
+   * Language alias
+   *
+   * @see https://shiki.style/guide/load-lang#custom-language-aliases
+   */
+  langAlias?: Record<string, StringLiteralUnion<BundledLanguage>>
+
+  /**
    * Fallback language when the specified language is not available.
    */
   defaultHighlightLang?: string
-
-  /**
-   * The single theme to use
-   *
-   * @see https://shiki.style/themes
-   */
-  theme?: ShikiTheme
-
-  /**
-   * The dark and light themes to use
-   *
-   * @see https://shiki.style/themes
-   */
-  themes?: {
-    dark: ShikiTheme
-    light: ShikiTheme
-  }
 
   /**
    * Function to customize Shiki highlighter instance.
    */
   shikiSetup?: (shiki: Highlighter) => void | Promise<void>
 
-  transformers?: ShikiTransformer[]
-
   /**
-   * The default theme applied to the code (via inline color style).
-   * The rest of the themes are applied via CSS variables, and toggled by CSS overrides.
+   * Shiki transformers
    */
-  defaultColor?: false | StringLiteralUnion<'light' | 'dark'>
+  transformers?: ShikiTransformer[]
 
   /**
    * Enable highlight lines or not


### PR DESCRIPTION
Our users don't need to know details about shiki if they only want to customize it with its themes and langs.

That should be the goal of most our users. So we should not provide tech docs to them. Instead, we should explain what is happening with these options.