### PR TITLE
fix(copy-code): ignoreSelector dose not work

### DIFF
--- a/plugins/features/plugin-copy-code/src/client/config.ts
+++ b/plugins/features/plugin-copy-code/src/client/config.ts
@@ -6,12 +6,14 @@ declare const __CC_DELAY__: number
 declare const __CC_DURATION__: number
 declare const __CC_LOCALES__: CopyCodePluginLocaleConfig
 declare const __CC_SELECTOR__: string[]
+declare const __CC_IGNORE_SELECTOR__: string[]
 declare const __CC_SHOW_IN_MOBILE__: boolean
 
 export default defineClientConfig({
   setup: () => {
     useCopyCode({
       selector: __CC_SELECTOR__,
+      ignoreSelector: __CC_IGNORE_SELECTOR__,
       locales: __CC_LOCALES__,
       duration: __CC_DURATION__,
       delay: __CC_DELAY__,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [X] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [X] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New feature
- [ ] Other

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I'm using `twoslash` in my blog building with `vuepress-theme-hope`, I need to ignore `twoslash` errors when using `copy-code`.

But it seems the `ignoreSelector` is not working.

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->

**Before**

**After**
