### PR TITLE
fix: correct spelling in RTL implementation

### DIFF
--- a/plugins/development/plugin-rtl/src/node/rtlPlugin.ts
+++ b/plugins/development/plugin-rtl/src/node/rtlPlugin.ts
@@ -25,7 +25,7 @@ export interface RTLPluginOptions {
 
 const __dirname = getDirname(import.meta.url)
 
-export const rltPlugin = (options: RTLPluginOptions = {}): PluginObject => ({
+export const rtlPlugin = (options: RTLPluginOptions = {}): PluginObject => ({
   name: '@vuepress/plugin-rtl',
 
   define: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [ ] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [ ] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Other

### Description

There was a spelling mistake in the rtlPlugin. When I attempted to retrieve the package, it returned an error saying that the package could not be found.
