### PR TITLE
feat(plugin-markdown-hint): improve hint container outlook

### DIFF
--- a/plugins/markdown/plugin-markdown-hint/src/client/styles/hint.scss
+++ b/plugins/markdown/plugin-markdown-hint/src/client/styles/hint.scss
@@ -8,7 +8,6 @@
   background: var(--hint-c-soft);
   transition:
     background var(--vp-t-color),
-    border-color var(--vp-t-color),
     color var(--vp-t-color);
 
   @media print {
@@ -36,20 +35,21 @@
   &.tip,
   &.warning,
   &.caution {
-    margin: 0.85rem 0;
-    padding: 0.25rem 1rem;
-    border-inline-start-width: 0.3rem;
-    border-inline-start-style: solid;
-    border-radius: 0.5rem;
+    margin-block: 0.75rem;
+    padding: 0.25em 1em;
+    border-radius: 0.5em;
 
     color: inherit;
 
-    @media (max-width: 419px) {
-      margin-inline: -0.75rem;
+    font-size: var(--hint-font-size);
+
+    @media print {
+      border-inline-start-width: 0.25em;
+      border-inline-start-style: solid;
     }
 
     .hint-container-title {
-      padding-inline-start: 1.75rem;
+      padding-inline-start: 1.75em;
 
       @media print {
         padding-inline-start: 0;
@@ -147,8 +147,8 @@
 
     display: block;
 
-    margin: 1rem 0;
-    padding: 1.5rem;
+    margin-block: 0.75rem;
+    padding: 1.25rem 1rem;
     border-radius: 0.5rem;
 
     background: var(--detail-c-bg);
@@ -156,10 +156,6 @@
     transition:
       background var(--vp-t-transform),
       color var(--vp-t-transform);
-
-    @media (max-width: 419px) {
-      margin-inline: -0.75rem;
-    }
 
     h4 {
       margin-top: 0;
@@ -184,11 +180,13 @@
     summary {
       position: relative;
 
-      margin: -1.5rem;
-      padding-block: 1.5rem;
-      padding-inline: 4rem 1.5rem;
+      margin: -1rem;
+      padding-block: 1em;
+      padding-inline: 3em 1.5em;
 
       list-style: none;
+
+      font-size: var(--hint-font-size);
 
       cursor: pointer;
 
@@ -202,32 +200,26 @@
         font-size: 0;
       }
 
-      &::before,
-      &::after {
+      &::before {
+        @include svg.mask-svg(icons.$detail-icon);
+
         content: ' ';
 
         position: absolute;
-        inset-inline-start: 1.5rem;
-        top: calc(50% - 0.75rem);
+        inset-inline-start: 0.8em;
+        top: calc(50% - 0.5em);
 
-        width: 1.5rem;
-        height: 1.5rem;
+        width: 1em;
+        height: 1em;
 
-        font-size: 1.5rem;
-      }
-
-      &::before {
-        border-radius: 50%;
-        background: var(--detail-c-icon);
-        transition:
-          background var(--vp-t-color),
-          transform var(--vp-t-transform);
-      }
-
-      &::after {
-        @include svg.mask-svg(icons.$detail-icon);
+        font-size: 1.25rem;
         line-height: normal;
-        transition: transform var(--vp-t-transform);
+
+        transition:
+          color,
+          var(--vp-t-color),
+          transform var(--vp-t-transform);
+
         transform: rotate(90deg);
       }
     }
@@ -235,7 +227,7 @@
     &[open] > summary {
       margin-bottom: 0.5em;
 
-      &::after {
+      &::before {
         transform: rotate(180deg);
       }
     }

--- a/plugins/markdown/plugin-markdown-hint/src/client/styles/vars.css
+++ b/plugins/markdown/plugin-markdown-hint/src/client/styles/vars.css
@@ -1,4 +1,6 @@
 :root {
+  --hint-font-size: 0.9rem;
+
   /* important */
   --important-c-accent: var(--vp-c-purple-bg);
   --important-c-text: var(--vp-c-purple-text);

--- a/themes/theme-default/src/client/styles/plugins.scss
+++ b/themes/theme-default/src/client/styles/plugins.scss
@@ -1,4 +1,5 @@
 @use 'mixins';
+@import 'variables';
 
 // plugin-comment
 .vp-comment {
@@ -16,5 +17,12 @@
   .search-box {
     vertical-align: top;
     flex: 0 0 auto;
+  }
+}
+
+// plugin-markdown-hint
+.hint-container {
+  @media screen and (max-width: $MQMobile) {
+    margin-inline: -0.75rem;
   }
 }


### PR DESCRIPTION
The hint container is a bit large in the context around it, so we shrink it:

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->

**Before**

![image](https://github.com/user-attachments/assets/f363a53b-26b4-4272-9f1d-fbb5f7b48162)

**After**

![image](https://github.com/user-attachments/assets/a78a05f4-d7f5-46ec-baf7-5d10816803eb)


Before:

![image](https://github.com/user-attachments/assets/8666f6da-2cce-43bf-ab18-6d8143d915fb)

After:

![image](https://github.com/user-attachments/assets/11916aea-1f58-4a19-be6b-52f4f477dbab)
