### PR TITLE
fix(theme-blog): prevent navbar overlap in blog components

### DIFF
--- a/e2e/docs/.vuepress/components/ArticleList.vue
+++ b/e2e/docs/.vuepress/components/ArticleList.vue
@@ -67,6 +67,7 @@ defineProps<{
   @include mixins.content-wrapper;
 
   & {
+    padding-top: calc(var(--navbar-height) + 1rem) !important;
     text-align: center;
   }
 }

--- a/e2e/docs/.vuepress/layouts/Category.vue
+++ b/e2e/docs/.vuepress/layouts/Category.vue
@@ -42,7 +42,7 @@ const categoryMap = useBlogCategory<ArticleInfo>('category')
   @include mixins.content-wrapper;
 
   & {
-    padding-top: 1rem !important;
+    padding-top: calc(var(--navbar-height) + 1rem) !important;
     padding-bottom: 0 !important;
     font-size: 14px;
   }

--- a/e2e/docs/.vuepress/layouts/Tag.vue
+++ b/e2e/docs/.vuepress/layouts/Tag.vue
@@ -42,7 +42,7 @@ const tagMap = useBlogCategory<ArticleInfo>('tag')
   @include mixins.content-wrapper;
 
   & {
-    padding-top: 1rem !important;
+    padding-top: calc(var(--navbar-height) + 1rem) !important;
     padding-bottom: 0 !important;
     font-size: 14px;
   }

--- a/e2e/docs/.vuepress/layouts/Timeline.vue
+++ b/e2e/docs/.vuepress/layouts/Timeline.vue
@@ -21,7 +21,7 @@ const timelines = useBlogType('timeline')
 
 <style lang="scss">
 .timeline-title {
-  padding: 0;
+  padding-top: calc(var(--navbar-height) + 1rem) !important;
   text-align: center;
 }
 </style>

--- a/tools/create-vuepress/template/blog/.vuepress/components/ArticleList.vue
+++ b/tools/create-vuepress/template/blog/.vuepress/components/ArticleList.vue
@@ -53,6 +53,7 @@ defineProps({
 
 .article-wrapper {
   @include mixins.content-wrapper;
+  padding-top: calc(var(--navbar-height) + 1rem) !important;
   text-align: center;
 }
 

--- a/tools/create-vuepress/template/blog/.vuepress/layouts/Category.vue
+++ b/tools/create-vuepress/template/blog/.vuepress/layouts/Category.vue
@@ -39,7 +39,7 @@ const categoryMap = useBlogCategory('category')
 .category-wrapper {
   @include mixins.content-wrapper;
 
-  padding-top: 1rem !important;
+  padding-top: calc(var(--navbar-height) + 1rem) !important;
   padding-bottom: 0 !important;
   font-size: 14px;
 

--- a/tools/create-vuepress/template/blog/.vuepress/layouts/Tag.vue
+++ b/tools/create-vuepress/template/blog/.vuepress/layouts/Tag.vue
@@ -39,7 +39,7 @@ const tagMap = useBlogCategory('tag')
 .tag-wrapper {
   @include mixins.content-wrapper;
 
-  padding-top: 1rem !important;
+  padding-top: calc(var(--navbar-height) + 1rem) !important;
   padding-bottom: 0 !important;
   font-size: 14px;
 

--- a/tools/create-vuepress/template/blog/.vuepress/layouts/Timeline.vue
+++ b/tools/create-vuepress/template/blog/.vuepress/layouts/Timeline.vue
@@ -20,7 +20,7 @@ const timelines = useBlogType('timeline')
 
 <style lang="scss">
 .timeline-title {
-  padding: 0;
+  padding-top: calc(var(--navbar-height) + 1rem) !important;
   text-align: center;
 }
 </style>


### PR DESCRIPTION
fix content overlap by adjusting padding in Category, Tag, Timeline and ArticleList components

# fix(theme-blog): prevent navbar overlap in blog components

## Description

This PR fixes the issue where content in blog components (Category, Tag, Timeline, and ArticleList) is partially hidden behind the navbar. The solution adds proper padding using the existing navbar height CSS variable.



### Before submitting the PR, please make sure you do the following
- [x] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving.

### What is the purpose of this pull request?
- [x] Bug fix
- [ ] New feature
- [ ] Other

### Technical Details

#### Modified files:
```
e2e/docs/vuepress/layouts/Category.vue
e2e/docs/vuepress/layouts/Tag.vue
e2e/docs/vuepress/layouts/Timeline.vue
e2e/docs/vuepress/layouts/ArticleList.vue

tools/create-vuepress/template/blog/.vuepress/layouts/Category.vue
tools/create-vuepress/template/blog/.vuepress/layouts/Tag.vue
tools/create-vuepress/template/blog/.vuepress/layouts/Timeline.vue
tools/create-vuepress/template/blog/.vuepress/layouts/ArticleList.vue
```

#### Changes:
```diff
// Category.vue, Tag.vue
.category-wrapper,
.tag-wrapper {
  @include mixins.content_wrapper;
+ padding-top: calc(var(--navbar-height) + 1rem) !important;
  padding-bottom: 0 !important;
}

// Timeline.vue
.timeline-title {
- padding: 0;
+ padding-top: calc(var(--navbar-height) + 1rem) !important;
  text-align: center;
}

// ArticleList.vue
.article-wrapper {
  @include mixins.content_wrapper;
+ padding-top: calc(var(--navbar-height) + 1rem) !important;
  text-align: center;
}
```

### Testing Notes 


- Tested on different screen sizes
- Verified with both light and dark themes
- Checked responsive behavior
- Tested in both e2e environment and template creation

### Screenshots

**Before**
<img src="https://github.com/user-attachments/assets/5cb9b388-c719-4255-a42b-011d1eab000c" alt="Article-0" style="zoom: 25%;" />
<img src="https://github.com/user-attachments/assets/e5bb98eb-f75b-4a23-b9d6-43dc25f98f5a" alt="Category-0" style="zoom:25%;" />
<img src="https://github.com/user-attachments/assets/55b7ef0a-dfde-46a5-94ee-6b9d0a6b6290" alt="Tag-0" style="zoom:25%;" />
<img src="https://github.com/user-attachments/assets/3a45e0d3-aff1-4afa-b7e1-67e8ef29ad21" alt="Timeline-0" style="zoom:25%;" />

**After**
<img src="https://github.com/user-attachments/assets/bdbf8086-ec21-4659-8e27-b1613aad0764" alt="Article-1" style="zoom:25%;" />
<img src="https://github.com/user-attachments/assets/2b0a3339-4b02-4711-8ca3-2dc482453932" alt="Category-1" style="zoom:25%;" />
<img src="https://github.com/user-attachments/assets/cd8e0dd3-39ca-4173-9f48-3809a6125b5b" alt="Tag-1" style="zoom:25%;" />
<img src="https://github.com/user-attachments/assets/36164df3-f9ca-4fea-a228-ede67161b0b7" alt="Timeline-1" style="zoom:25%;" />