### PR TITLE
fix(helper): `.sr-only` clip

### DIFF
--- a/tools/helper/src/client/styles/sr-only.scss
+++ b/tools/helper/src/client/styles/sr-only.scss
@@ -3,7 +3,7 @@
     position: absolute;
 
     overflow: hidden;
-    clip: rect (0, 0, 0, 0);
+    clip-path: rect(0 0 0 0);
 
     width: 1px;
     height: 1px;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Other

### Description

`clip` has been [deprecated](https://developer.mozilla.org/en-US/docs/Web/CSS/clip), and `rect (0, 0, 0, 0)` should be `rect(0 0 0 0)`