### PR TITLE
feat(plugin-seo): improve `getCover`

### DIFF
--- a/plugins/seo/plugin-seo/src/node/utils/getCover.ts
+++ b/plugins/seo/plugin-seo/src/node/utils/getCover.ts
@@ -1,7 +1,28 @@
-import { isLinkAbsolute, isLinkWithProtocol } from '@vuepress/helper'
+import {
+  isLinkAbsolute,
+  isLinkWithProtocol,
+  isPlainObject,
+  isString,
+} from '@vuepress/helper'
 import type { App } from 'vuepress/core'
 import type { ExtendPage } from '../../typings/index.js'
 import { getUrl } from './getUrl.js'
+
+const resolveCover = (
+  cover: Record<string, unknown> | string | undefined,
+): string | undefined => {
+  if (!cover) {
+    return undefined
+  }
+  if (isString(cover)) {
+    return cover
+  }
+  if (isPlainObject(cover)) {
+    return (cover.url ?? cover.src) as string
+  }
+
+  return undefined
+}
 
 export const getCover = (
   { frontmatter }: ExtendPage,
@@ -10,14 +31,11 @@ export const getCover = (
 ): string | null => {
   const { banner, cover } = frontmatter
 
-  if (banner) {
-    if (isLinkAbsolute(banner)) return getUrl(hostname, base, banner)
-    if (isLinkWithProtocol(banner)) return banner
-  }
+  const url = resolveCover(banner) ?? resolveCover(cover)
 
-  if (cover) {
-    if (isLinkAbsolute(cover)) return getUrl(hostname, base, cover)
-    if (isLinkWithProtocol(cover)) return cover
+  if (url) {
+    if (isLinkAbsolute(url)) return getUrl(hostname, base, url)
+    if (isLinkWithProtocol(url)) return url
   }
 
   return null

--- a/plugins/seo/plugin-seo/src/typings/frontmatter.ts
+++ b/plugins/seo/plugin-seo/src/typings/frontmatter.ts
@@ -45,12 +45,12 @@ export interface SEOPluginFrontmatter extends PageFrontmatter {
    *
    * 页面封面
    */
-  cover?: string
+  cover?: Record<string, unknown> | string
 
   /**
    * Page Banner
    *
    * 页面 Banner 图
    */
-  banner?: string
+  banner?: Record<string, unknown> | string
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New feature
- [ ] Other

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently, the `plugin-seo` assumes that the cover image configuration field is a `string`, but the actual situation may be more complex. For example, if `cover` is of an object type, the current `getCover` may encounter errors that lead to build failures.