### PR TITLE
处理每切换一次页面就增加一条sidebarItems数据的问题

### DIFF
--- a/themes/theme-default/src/client/composables/useSidebarItems.ts
+++ b/themes/theme-default/src/client/composables/useSidebarItems.ts
@@ -27,15 +27,6 @@ export type HeadersRef = Ref<MenuItem[]>
 
 export const headersRef: HeadersRef = ref([])
 
-onMounted(() => {
-  const router = useRouter()
-  router.beforeEach((to, from) => {
-    if (to.path !== from.path) {
-      headersRef.value = []
-    }
-  })
-})
-
 export const setupHeaders = (): void => {
   const themeLocale = useThemeLocaleData()
   const frontmatter = usePageFrontmatter<DefaultThemeNormalPageFrontmatter>()
@@ -231,6 +222,7 @@ export const setupSidebarItems = (): void => {
   >()
   const page = usePageData()
   const route = useRoute()
+  const router = useRouter()
   const routeLocale = useRouteLocale()
   const headers = useHeaders()
 
@@ -252,4 +244,10 @@ export const setupSidebarItems = (): void => {
     ),
   )
   provide(sidebarItemsSymbol, sidebarItems)
+
+  router.beforeEach((to, from) => {
+    if (to.path !== from.path) {
+      headersRef.value = []
+    }
+  })
 }

--- a/themes/theme-default/src/client/composables/useSidebarItems.ts
+++ b/themes/theme-default/src/client/composables/useSidebarItems.ts
@@ -27,6 +27,15 @@ export type HeadersRef = Ref<MenuItem[]>
 
 export const headersRef: HeadersRef = ref([])
 
+onMounted(() => {
+  const router = useRouter();
+  router.beforeEach((to, from) => {
+    if (to.path !== from.path) {
+      headersRef.value = [];
+    }
+  });
+});
+
 export const setupHeaders = (): void => {
   const router = useRouter()
   const themeLocale = useThemeLocaleData()
@@ -34,12 +43,6 @@ export const setupHeaders = (): void => {
   const levels = computed(
     () => frontmatter.value.sidebarDepth ?? themeLocale.value.sidebarDepth ?? 2,
   )
-
-  router.beforeEach((to, from) => {
-    if (to.path !== from.path) {
-      headersRef.value = []
-    }
-  })
 
   const updateHeaders = (): void => {
     if (levels.value <= 0) {

--- a/themes/theme-default/src/client/composables/useSidebarItems.ts
+++ b/themes/theme-default/src/client/composables/useSidebarItems.ts
@@ -28,16 +28,15 @@ export type HeadersRef = Ref<MenuItem[]>
 export const headersRef: HeadersRef = ref([])
 
 onMounted(() => {
-  const router = useRouter();
+  const router = useRouter()
   router.beforeEach((to, from) => {
     if (to.path !== from.path) {
-      headersRef.value = [];
+      headersRef.value = []
     }
-  });
-});
+  })
+})
 
 export const setupHeaders = (): void => {
-  const router = useRouter()
   const themeLocale = useThemeLocaleData()
   const frontmatter = usePageFrontmatter<DefaultThemeNormalPageFrontmatter>()
   const levels = computed(


### PR DESCRIPTION
问题：
在使用useSidebarItems时，watch监听sidebarItems，发现每切换一次页面，sidebarItems打印的数量就加一
`
watch(sidebarItems,(n)=>{
  console.log(n)
})
`
处理：
可能原因是VPPage组件中调用setupHeaders函数中，此函数每调用一次会给router添加一次beforeEach，导致headersRef改变，从而影响provide的sidebarItems的改变。