### PR TITLE
Fix import for @vuepress/plugin-blog/client

### DIFF
--- a/docs/plugins/blog/blog/guide.md
+++ b/docs/plugins/blog/blog/guide.md
@@ -167,7 +167,7 @@ So with node side settings above, you can get information about "tag" and "star"
 
 ```vue
 <script setup lang="ts">
-import { useBlogCategory } from '@vuepress/plugin-blog'
+import { useBlogCategory } from '@vuepress/plugin-blog/client'
 import { RouteLink } from 'vuepress/client'
 
 const categoryMap = useBlogCategory('tag')
@@ -194,7 +194,7 @@ const categoryMap = useBlogCategory('tag')
 
 ```vue
 <script setup lang="ts">
-import { useBlogCategory } from '@vuepress/plugin-blog'
+import { useBlogCategory } from '@vuepress/plugin-blog/client'
 
 const categoryMap = useBlogCategory('tag')
 </script>


### PR DESCRIPTION
This was causing an error: "useBlogCategory" is not exported by "node_modules/@vuepress/plugin-blog/lib/node/index.js"
