### PR TITLE
Update guide.md with missing title in getInfo option

### DIFF
--- a/docs/plugins/blog/blog/guide.md
+++ b/docs/plugins/blog/blog/guide.md
@@ -44,9 +44,10 @@ export default {
         return true
       },
 
-      getInfo: ({ frontmatter, git = {}, data = {} }) => {
+      getInfo: ({ frontmatter, title, git = {}, data = {} }) => {
         // getting page info
         const info: Record<string, unknown> = {
+          title,
           author: frontmatter.author || '',
           categories: frontmatter.categories || [],
           date: frontmatter.date || git.createdTime || null,

--- a/docs/zh/plugins/blog/blog/guide.md
+++ b/docs/zh/plugins/blog/blog/guide.md
@@ -40,9 +40,10 @@ export default {
         return true
       },
 
-      getInfo: ({ frontmatter, git = {}, data = {} }) => {
+      getInfo: ({ frontmatter, title, git = {}, data = {} }) => {
         // 获取页面信息
         const info: Record<string, unknown> = {
+          title,
           author: frontmatter.author || '',
           categories: frontmatter.categories || [],
           date: frontmatter.date || git.createdTime || null,


### PR DESCRIPTION
`title`property is used in `TagList` or `StarList` components -  https://ecosystem.vuejs.press/plugins/blog/blog/guide.html#customizing-categories-and-types

It done similarly to an e2e example - https://github.com/vuepress/ecosystem/blob/main/e2e/docs/.vuepress/config.ts#L120