### PR TITLE
feat: disable `line-numbers` within `twoslash` code block

### DIFF
--- a/docs/plugins/markdown/shiki.md
+++ b/docs/plugins/markdown/shiki.md
@@ -734,6 +734,16 @@ body > div {
   console.log(a + b)
   ```
 
+  ::: warning
+
+  For code blocks that have `twoslash` enabled:
+
+  - Do not add the `:v-pre` marker in the code block, as this will cause `twoslash` to fail to run properly.
+
+  - To avoid layout conflicts, code blocks will no longer display line numbers.
+
+  :::
+
 ## Advanced Options
 
 ### defaultLang

--- a/docs/zh/plugins/markdown/shiki.md
+++ b/docs/zh/plugins/markdown/shiki.md
@@ -736,6 +736,15 @@ body > div {
   console.log(a + b)
   ```
 
+  ::: warning
+
+  对于启用了 `twoslash` 的代码块：
+
+  - 不要在代码块中添加 `:v-pre` 标记, 这会导致 `twoslash` 无法正常运行。
+  - 为避免布局上的冲突，代码块不再显示 **行数** 。
+
+  :::
+
 ## 高级选项
 
 ### defaultLang

--- a/plugins/markdown/plugin-shiki/src/node/shikiPlugin.ts
+++ b/plugins/markdown/plugin-shiki/src/node/shikiPlugin.ts
@@ -20,7 +20,7 @@ import {
 } from './markdown/index.js'
 import type { ShikiPluginOptions } from './options.js'
 import { prepareClientConfigFile } from './prepareClientConfigFile.js'
-import { logger } from './utils.js'
+import { TWOSLASH_RE, logger } from './utils.js'
 
 export const shikiPlugin = (_options: ShikiPluginOptions = {}): Plugin => {
   return (app) => {
@@ -91,6 +91,12 @@ export const shikiPlugin = (_options: ShikiPluginOptions = {}): Plugin => {
         if (preWrapper) {
           md.use<MarkdownItLineNumbersOptions>(lineNumbersPlugin, {
             lineNumbers,
+            resolveLineNumbers(info) {
+              if (options.twoslash) {
+                return TWOSLASH_RE.test(info) ? false : undefined
+              }
+              return undefined
+            },
           })
           md.use<MarkdownItCollapsedLinesOptions>(collapsedLinesPlugin, {
             collapsedLines,

--- a/plugins/markdown/plugin-shiki/src/node/shikiPlugin.ts
+++ b/plugins/markdown/plugin-shiki/src/node/shikiPlugin.ts
@@ -92,10 +92,9 @@ export const shikiPlugin = (_options: ShikiPluginOptions = {}): Plugin => {
           md.use<MarkdownItLineNumbersOptions>(lineNumbersPlugin, {
             lineNumbers,
             resolveLineNumbers(info) {
-              if (options.twoslash) {
-                return TWOSLASH_RE.test(info) ? false : undefined
-              }
-              return undefined
+              return options.twoslash && TWOSLASH_RE.test(info)
+                ? false
+                : undefined
             },
           })
           md.use<MarkdownItCollapsedLinesOptions>(collapsedLinesPlugin, {

--- a/plugins/markdown/plugin-shiki/src/node/utils.ts
+++ b/plugins/markdown/plugin-shiki/src/node/utils.ts
@@ -4,6 +4,8 @@ import { customAlphabet } from 'nanoid'
 
 const VUE_RE = /-vue$/
 
+export const TWOSLASH_RE = /\btwoslash\b/
+
 export const PLUGIN_NAME = '@vuepress/plugin-shiki'
 
 export const logger = new Logger(PLUGIN_NAME)

--- a/tools/highlighter-helper/src/node/lineNumbers/options.ts
+++ b/tools/highlighter-helper/src/node/lineNumbers/options.ts
@@ -14,4 +14,12 @@ export interface MarkdownItLineNumbersOptions {
    * @default false
    */
   removeLastLine?: boolean
+
+  /**
+   * Custom resolving function that whether to enable line numbers for a single code block
+   * @returns `boolean | undefined`
+   *  - `boolean` - Whether to enable line numbers
+   *  - `undefined` - built-in resolving
+   */
+  resolveLineNumbers?: (info: string) => boolean | undefined
 }

--- a/tools/highlighter-helper/src/node/lineNumbers/plugin.ts
+++ b/tools/highlighter-helper/src/node/lineNumbers/plugin.ts
@@ -7,6 +7,7 @@ export const lineNumbers = (
   {
     lineNumbers: lineNumberOptions = true,
     removeLastLine,
+    resolveLineNumbers: customResolveLineNumbers,
   }: MarkdownItLineNumbersOptions = {},
 ): void => {
   const rawFence = md.renderer.rules.fence!
@@ -31,6 +32,7 @@ export const lineNumbers = (
 
     // resolve line-numbers mark from token info
     const lineNumbersInfo =
+      customResolveLineNumbers?.(info) ??
       resolveLineNumbers(info) ??
       (typeof lineNumberOptions === 'number'
         ? lines.length >= lineNumberOptions


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [ ] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [ ] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New feature
- [ ] Other

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->

**Before**

**After**
