### PR TITLE
feat(helper): add `!important` into transition properties

### DIFF
--- a/tools/helper/src/client/styles/transition/fade-in-down.scss
+++ b/tools/helper/src/client/styles/transition/fade-in-down.scss
@@ -7,14 +7,14 @@
 .fade-in-down {
   &-enter-from,
   &-leave-to {
-    opacity: 0;
-    transform: translateY(var(--transition-fade-in-down-offset));
+    opacity: 0 !important;
+    transform: translateY(var(--transition-fade-in-down-offset)) !important;
   }
 
   &-enter-to,
   &-leave-from {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) !important;
   }
 
   &-leave-active {

--- a/tools/helper/src/client/styles/transition/fade-in-height-expand.scss
+++ b/tools/helper/src/client/styles/transition/fade-in-height-expand.scss
@@ -17,7 +17,7 @@
   }
 
   &-leave-active {
-    overflow: hidden;
+    overflow: hidden !important;
     transition:
       max-height var(--transition-slow-duration) var(--transition-ease-in-out),
       opacity var(--transition-leave-duration) var(--transition-ease-out),
@@ -30,7 +30,7 @@
   }
 
   &-enter-active {
-    overflow: hidden;
+    overflow: hidden !important;
     transition:
       max-height var(--transition-slow-duration) var(--transition-ease-in-out),
       opacity var(--transition-enter-duration) var(--transition-ease-in),

--- a/tools/helper/src/client/styles/transition/fade-in-left.scss
+++ b/tools/helper/src/client/styles/transition/fade-in-left.scss
@@ -7,14 +7,14 @@
 .fade-in-left {
   &-enter-from,
   &-leave-to {
-    opacity: 0;
-    transform: translateX(var(--transition-fade-in-left-offset));
+    opacity: 0 !important;
+    transform: translateX(var(--transition-fade-in-left-offset)) !important;
   }
 
   &-enter-to,
   &-leave-from {
     opacity: 1;
-    transform: translateX(0);
+    transform: translateX(0) !important;
   }
 
   &-leave-active {

--- a/tools/helper/src/client/styles/transition/fade-in-right.scss
+++ b/tools/helper/src/client/styles/transition/fade-in-right.scss
@@ -4,17 +4,17 @@
   --transition-fade-in-right-offset: -10px;
 }
 
-.fade-in-left {
+.fade-in-right {
   &-enter-from,
   &-leave-to {
-    opacity: 0;
-    transform: translateX(var(--transition-fade-in-right-offset));
+    opacity: 0 !important;
+    transform: translateX(var(--transition-fade-in-right-offset)) !important;
   }
 
   &-enter-to,
   &-leave-from {
     opacity: 1;
-    transform: translateX(0);
+    transform: translateX(0) !important;
   }
 
   &-leave-active {

--- a/tools/helper/src/client/styles/transition/fade-in-scale-up.scss
+++ b/tools/helper/src/client/styles/transition/fade-in-scale-up.scss
@@ -13,7 +13,7 @@
         var(--transition-ease-in),
       transform var(--transition-fade-in-scale-up-duration)
         var(--transition-ease-in) !important;
-    transform-origin: var(--transition-fade-in-scale-up-origin);
+    transform-origin: var(--transition-fade-in-scale-up-origin) !important;
   }
 
   &-enter-active {
@@ -22,18 +22,18 @@
         var(--transition-ease-out),
       transform var(--transition-fade-in-scale-up-duration)
         var(--transition-ease-out) !important;
-    transform-origin: var(--transition-fade-in-scale-up-origin);
+    transform-origin: var(--transition-fade-in-scale-up-origin) !important;
   }
 
   &-enter-from,
   &-leave-to {
-    opacity: 0;
-    transform: scale(var(--transition-fade-in-scale-up-scale));
+    opacity: 0 !important;
+    transform: scale(var(--transition-fade-in-scale-up-scale)) !important;
   }
 
   &-leave-from,
   &-enter-to {
     opacity: 1;
-    transform: scale(1);
+    transform: scale(1) !important;
   }
 }

--- a/tools/helper/src/client/styles/transition/fade-in-up.scss
+++ b/tools/helper/src/client/styles/transition/fade-in-up.scss
@@ -7,14 +7,14 @@
 .fade-in-up {
   &-enter-from,
   &-leave-to {
-    opacity: 0;
-    transform: translateY(var(--transition-fade-in-up-offset));
+    opacity: 0 !important;
+    transform: translateY(var(--transition-fade-in-up-offset)) !important;
   }
 
   &-enter-to,
   &-leave-from {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) !important;
   }
 
   &-leave-active {

--- a/tools/helper/src/client/styles/transition/fade-in-width-expand.scss
+++ b/tools/helper/src/client/styles/transition/fade-in-width-expand.scss
@@ -14,7 +14,7 @@
   }
 
   &-leave-active {
-    overflow: hidden;
+    overflow: hidden !important;
     transition:
       max-width var(--transition-leave-duration) var(--transition-ease-in-out)
         var(--transition-delay),
@@ -26,7 +26,7 @@
   }
 
   &-enter-active {
-    overflow: hidden;
+    overflow: hidden !important;
     transition:
       max-width var(--transition-enter-duration) var(--transition-ease-in-out),
       opacity var(--transition-leave-duration) var(--transition-ease-in-out)

--- a/tools/helper/src/client/styles/transition/fade-in.scss
+++ b/tools/helper/src/client/styles/transition/fade-in.scss
@@ -8,7 +8,7 @@
 
   &-enter-from,
   &-leave-to {
-    opacity: 0;
+    opacity: 0 !important;
   }
 
   &-leave-from,

--- a/tools/helper/src/client/styles/transition/slide-in-down.scss
+++ b/tools/helper/src/client/styles/transition/slide-in-down.scss
@@ -17,11 +17,11 @@
 
   &-enter-to,
   &-leave-from {
-    transform: translateY(0);
+    transform: translateY(0) !important;
   }
 
   &-enter-from,
   &-leave-to {
-    transform: translateY(var(--transition-slide-in-down-offset));
+    transform: translateY(var(--transition-slide-in-down-offset)) !important;
   }
 }

--- a/tools/helper/src/client/styles/transition/slide-in-left.scss
+++ b/tools/helper/src/client/styles/transition/slide-in-left.scss
@@ -17,11 +17,11 @@
 
   &-enter-to,
   &-leave-from {
-    transform: translateX(0);
+    transform: translateX(0) !important;
   }
 
   &-enter-from,
   &-leave-to {
-    transform: translateX(var(--transition-slide-in-left-offset));
+    transform: translateX(var(--transition-slide-in-left-offset)) !important;
   }
 }

--- a/tools/helper/src/client/styles/transition/slide-in-right.scss
+++ b/tools/helper/src/client/styles/transition/slide-in-right.scss
@@ -17,11 +17,11 @@
 
   &-enter-to,
   &-leave-from {
-    transform: translateX(0);
+    transform: translateX(0) !important;
   }
 
   &-enter-from,
   &-leave-to {
-    transform: translateX(var(--transition-slide-in-right-offset));
+    transform: translateX(var(--transition-slide-in-right-offset)) !important;
   }
 }

--- a/tools/helper/src/client/styles/transition/slide-in-up.scss
+++ b/tools/helper/src/client/styles/transition/slide-in-up.scss
@@ -17,11 +17,11 @@
 
   &-enter-to,
   &-leave-from {
-    transform: translateY(0);
+    transform: translateY(0) !important;
   }
 
   &-enter-from,
   &-leave-to {
-    transform: translateY(var(--transition-slide-in-up-offset));
+    transform: translateY(var(--transition-slide-in-up-offset)) !important;
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New feature
- [ ] Other

### Description

I believe it is necessary to elevate the priority of transition properties.

Although doing so may cause layout flickering at the start and end of a transition when the element already has these configured transition properties.

However, when the priority of the same transition properties is too low, the transition animations cannot function properly.

I think we should prioritize ensuring that transition animations have a higher priority.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->

**Before**

**After**
