### PR TITLE
feat(plugin-sitemap): sitemap is always written to robots

### DIFF
--- a/plugins/seo/plugin-sitemap/src/node/outputSitemap.ts
+++ b/plugins/seo/plugin-sitemap/src/node/outputSitemap.ts
@@ -25,23 +25,39 @@ export const outputSitemap = async (
 
   const robotTxtPath = dir.dest('robots.txt')
 
+  const { succeed } = logger.load(
+    `Appended sitemap path to ${colors.cyan('robots.txt')}`,
+  )
   if (fs.existsSync(robotTxtPath)) {
-    const { succeed } = logger.load(
-      `Appended sitemap path to ${colors.cyan('robots.txt')}`,
-    )
-
     const robotsTxt = await fs.readFile(robotTxtPath, 'utf-8')
 
-    const newRobotsTxtContent = `${robotsTxt.replace(
-      /^Sitemap: .*$/u,
-      '',
-    )}\nSitemap: ${hostname}${base}${sitemapPath}\n`
+    const includesSitmap = robotsTxt.includes('Sitemap')
 
-    await fs.writeFile(robotTxtPath, newRobotsTxtContent, {
+    if (includesSitmap) {
+      const newRobotsTxtContent = `${robotsTxt.replace(
+        /^Sitemap: .*$/u,
+        '',
+      )}\nSitemap: ${hostname}${base}${sitemapPath}\n`
+
+      await fs.writeFile(robotTxtPath, newRobotsTxtContent, {
+        encoding: 'utf-8',
+        flag: 'w',
+      })
+    } else {
+      const robotsSitemap = `\nSitemap: ${hostname}${base}${sitemapPath}\n`
+
+      await fs.writeFile(robotTxtPath, robotsSitemap, {
+        encoding: 'utf-8',
+        flag: 'a',
+      })
+    }
+  } else {
+    const robotsSitemap = `Sitemap: ${hostname}${base}${sitemapPath}\n`
+    await fs.writeFile(robotTxtPath, robotsSitemap, {
       encoding: 'utf-8',
       flag: 'w',
     })
-
-    succeed()
   }
+
+  succeed()
 }

--- a/plugins/seo/plugin-sitemap/src/node/outputSitemap.ts
+++ b/plugins/seo/plugin-sitemap/src/node/outputSitemap.ts
@@ -24,36 +24,29 @@ export const outputSitemap = async (
   logger.succeed(`Generating sitemap to ${colors.cyan(sitemapPath)}`)
 
   const robotTxtPath = dir.dest('robots.txt')
+  const sitemapDeclaration = `Sitemap: ${hostname}${base}${sitemapPath}\n`
 
   const { succeed } = logger.load(
     `Appended sitemap path to ${colors.cyan('robots.txt')}`,
   )
   if (fs.existsSync(robotTxtPath)) {
     const robotsTxt = await fs.readFile(robotTxtPath, 'utf-8')
+    const siteMapRegex = /^Sitemap: .*$/mu
 
-    const includesSitmap = robotsTxt.includes('Sitemap')
-
-    if (includesSitmap) {
-      const newRobotsTxtContent = `${robotsTxt.replace(
-        /^Sitemap: .*$/u,
-        '',
-      )}\nSitemap: ${hostname}${base}${sitemapPath}\n`
-
-      await fs.writeFile(robotTxtPath, newRobotsTxtContent, {
-        encoding: 'utf-8',
-        flag: 'w',
-      })
+    if (siteMapRegex.test(robotsTxt)) {
+      await fs.writeFile(
+        robotTxtPath,
+        robotsTxt.replace(siteMapRegex, sitemapDeclaration),
+        { encoding: 'utf-8', flag: 'w' },
+      )
     } else {
-      const robotsSitemap = `\nSitemap: ${hostname}${base}${sitemapPath}\n`
-
-      await fs.writeFile(robotTxtPath, robotsSitemap, {
+      await fs.writeFile(robotTxtPath, `\n${sitemapDeclaration}`, {
         encoding: 'utf-8',
         flag: 'a',
       })
     }
   } else {
-    const robotsSitemap = `Sitemap: ${hostname}${base}${sitemapPath}\n`
-    await fs.writeFile(robotTxtPath, robotsSitemap, {
+    await fs.writeFile(robotTxtPath, sitemapDeclaration, {
       encoding: 'utf-8',
       flag: 'w',
     })

--- a/plugins/seo/plugin-sitemap/src/node/outputSitemap.ts
+++ b/plugins/seo/plugin-sitemap/src/node/outputSitemap.ts
@@ -27,7 +27,7 @@ export const outputSitemap = async (
   const sitemapDeclaration = `Sitemap: ${hostname}${base}${sitemapPath}\n`
 
   const { succeed } = logger.load(
-    `Appended sitemap path to ${colors.cyan('robots.txt')}`,
+    `Appending sitemap path to ${colors.cyan('robots.txt')}`,
   )
   if (fs.existsSync(robotTxtPath)) {
     const robotsTxt = await fs.readFile(robotTxtPath, 'utf-8')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [X] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [X] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New feature
- [X] Other

### Description
- Sitemap is always written to robots.txt
- If Sitemap does not exist in robots.txt, append the file to avoid overwriting

