### PR TITLE
feat(plugin-markdown-image): allow 'strict' in size

### DIFF
--- a/docs/plugins/markdown/markdown-image.md
+++ b/docs/plugins/markdown/markdown-image.md
@@ -68,11 +68,11 @@ interface ImageMarkOptions {
 
 ### Image Size
 
-You can use `|widthxheight` to specify the image size at the end of image alt.
+When you set `size: true` in plugin options, you can use `|widthxheight` to specify the image size at the end of image alt.
 
 Both `width` and `height` should be number which means size in pixels, and both of them are optional (set `0` to indicate ignore).
 
-If you want the same behavior as Obsidian, you can pass `{ strict: true }` in plugin options. Now both `width` and `height` are both required to be set (one of them can be `0` to scale with radio according to the other).
+If you want the same behavior as Obsidian, you can set `size: 'strict'` in plugin options, so `width` and `height` are both required to be set (one of them can be `0` to scale with radio according to the other).
 
 ```md
 ![Logo|200x200](/example.png)
@@ -110,7 +110,7 @@ The legacy grammar will break image rendering in environment that doesn't suppor
 
 :::
 
-You can use `=widthxheight` to specify the image size when setting `size: true` in plugin options.
+You can use `=widthxheight` to specify the image size at the end of the link when setting `legacy: true` in plugin options.
 
 ```md
 ![Alt](/example.png =200x300)
@@ -184,9 +184,8 @@ If the image is standalone in a line, wrapped or not wrapped by link, it will be
 
 ### size
 
-- Type: `boolean`
-- Details:
-  Whether enable image size support.
+- Type: `boolean | 'strict'`
+- Details: Whether enable image size support. `strict` requires implicit set with `0` to ignore width or height.
 
 ### legacySize
 

--- a/docs/zh/plugins/markdown/markdown-image.md
+++ b/docs/zh/plugins/markdown/markdown-image.md
@@ -68,11 +68,11 @@ interface ImageMarkOptions {
 
 ### 图片尺寸
 
-你可以在图片链接末尾使用 `|widthxheight` 来指定图片尺寸。
+当你在插件选项中设置 `size: true` 时，你可以在图片链接末尾使用 `|widthxheight` 来指定图片尺寸。
 
 `width` 和 `height` 都应该为数字并意味着像素单位的尺寸，并且它们两者都是可选的（设置 `0` 来表示忽略）。
 
-如果你想要与 Obsidian 相同的行为，你可以在插件选项中传递 `{ strict: true }`。现在 `width` 和 `height` 都必须被设置（其中一个可以是 `0` 来根据另一个按比例缩放）。
+如果你想要与 Obsidian 相同的行为，你可以在插件选项中设置 `size: 'strict'`，这样 `width` 和 `height` 都必须被设置（其中一个可以是 `0` 来根据另一个按比例缩放）。
 
 ```md
 ![Logo|200x200](/example.png)
@@ -110,7 +110,7 @@ interface ImageMarkOptions {
 
 :::
 
-当你在插件选项中设置 `size: true` 时，可以使用 `=widthxheight` 指定图像大小。
+当你在插件选项中设置 `legacySize: true` 时，可以使用 `=widthxheight` 指定图像大小。
 
 ```md
 ![Alt](/example.png =200x300)
@@ -184,8 +184,8 @@ interface ImageMarkOptions {
 
 ### size
 
-- 类型：`boolean`
-- 详情：是否启用图片尺寸支持。
+- 类型：`boolean | 'strict'`
+- 详情：是否启用图片尺寸支持。`strict` 需要隐式设置 `0` 来忽略宽度或高度。
 
 ### legacySize
 

--- a/docs/zh/plugins/markdown/markdown-image.md
+++ b/docs/zh/plugins/markdown/markdown-image.md
@@ -185,7 +185,7 @@ interface ImageMarkOptions {
 ### size
 
 - 类型：`boolean | 'strict'`
-- 详情：是否启用图片尺寸支持。`strict` 需要隐式设置 `0` 来忽略宽度或高度。
+- 详情：是否启用图片尺寸支持。`strict` 需要显式设置 `0` 来忽略宽度或高度。
 
 ### legacySize
 

--- a/docs/zh/plugins/markdown/markdown-image.md
+++ b/docs/zh/plugins/markdown/markdown-image.md
@@ -110,7 +110,7 @@ interface ImageMarkOptions {
 
 :::
 
-当你在插件选项中设置 `legacySize: true` 时，可以使用 `=widthxheight` 指定图像大小。
+当你在插件选项中设置 `legacySize: true` 时，可以在链接末尾使用 `=widthxheight` 指定图像大小。
 
 ```md
 ![Alt](/example.png =200x300)

--- a/plugins/markdown/plugin-markdown-image/src/node/markdownImagePlugin.ts
+++ b/plugins/markdown/plugin-markdown-image/src/node/markdownImagePlugin.ts
@@ -19,7 +19,8 @@ export const markdownImagePlugin = (
 
     if (options.figure) md.use(figure)
     if (options.lazyload) md.use(imgLazyload)
-    if (options.size) md.use(imgSize)
+    if (options.size)
+      md.use(imgSize, options.size === 'strict' ? { strict: true } : {})
     if (options.legacySize) md.use(legacyImgSize)
     if (mark)
       md.use<MarkdownItImgMarkOptions>(imgMark, isPlainObject(mark) ? mark : {})

--- a/plugins/markdown/plugin-markdown-image/src/node/options.ts
+++ b/plugins/markdown/plugin-markdown-image/src/node/options.ts
@@ -36,7 +36,7 @@ export interface MarkdownImagePluginOptions {
    *
    * @default false
    */
-  size?: boolean
+  size?: boolean | 'strict'
 
   /**
    * Whether to enable legacy image size mark support


### PR DESCRIPTION
This PR allow setting `'strict'` with `size` and fixes some wrong documentation introduced by https://github.com/vuepress/ecosystem/pull/449. cc @LincZero 