### PR TITLE
feat(highlighter-helper): helper to inject icons for code-title-bar

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -1,3 +1,5 @@
+@use '@vuepress/highlighter-helper/scss/code-title-icon';
+
 :root {
   --code-c-bg: #fafafa;
   --code-tabs-c-text: var(--vp-c-text);
@@ -9,20 +11,20 @@
   --code-tabs-c-bg: #181819;
 }
 
-.code-block-title-bar[data-title^='.vuepress/config.ts'] {
-  display: flex;
-  align-items: center;
-
-  &::before {
-    content: ' ';
-
-    display: inline-block;
-
-    width: 1.5em;
-    height: 1.5em;
-    margin-inline-end: 0.5em;
-
-    background: url('https://ecosystem.vuejs.press/images/hero.png') no-repeat
-      center / contain;
-  }
-}
+@include code-title-icon.style(
+  (
+    title: '.vuepress/config.ts',
+    match: 'equals',
+    icon: 'https://ecosystem.vuejs.press/images/hero.png',
+  ),
+  (
+    title: '.vuepress/client.ts',
+    match: 'equals',
+    icon: 'https://ecosystem.vuejs.press/images/hero.png',
+  ),
+  (
+    title: '.scss',
+    match: 'endsWith',
+    icon: 'https://sass-lang.com/assets/img/logos/logo.svg',
+  )
+);

--- a/docs/package.json
+++ b/docs/package.json
@@ -38,6 +38,7 @@
     "@vuepress/plugin-search": "workspace:*",
     "@vuepress/plugin-shiki": "workspace:*",
     "@vuepress/shiki-twoslash": "workspace:*",
+    "@vuepress/highlighter-helper": "workspace:*",
     "@vuepress/theme-default": "workspace:*",
     "@vueuse/core": "catalog:",
     "katex": "0.16.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@vuepress/helper':
         specifier: workspace:*
         version: link:../tools/helper
+      '@vuepress/highlighter-helper':
+        specifier: workspace:*
+        version: link:../tools/highlighter-helper
       '@vuepress/plugin-back-to-top':
         specifier: workspace:*
         version: link:../plugins/features/plugin-back-to-top

--- a/tools/highlighter-helper/package.json
+++ b/tools/highlighter-helper/package.json
@@ -27,12 +27,14 @@
     ".": "./lib/node/index.js",
     "./client": "./lib/client/index.js",
     "./styles/*": "./lib/client/styles/*",
+    "./scss/*": "./scss/*.scss",
     "./package.json": "./package.json"
   },
   "main": "./lib/node/index.js",
   "types": "./lib/node/index.d.ts",
   "files": [
-    "lib"
+    "lib",
+    "scss"
   ],
   "scripts": {
     "build": "tsc -b tsconfig.build.json",

--- a/tools/highlighter-helper/scss/code-title-icon.scss
+++ b/tools/highlighter-helper/scss/code-title-icon.scss
@@ -1,0 +1,65 @@
+@use 'sass:list';
+@use 'sass:map';
+
+@function get-selector($title, $match) {
+  @if $match == 'equals' {
+    @return '[data-title="#{$title}"]';
+  } @else if $match == 'startsWith' {
+    @return '[data-title^="#{$title}"]';
+  } @else if $match == 'endsWith' {
+    @return '[data-title$="#{$title}"]';
+  } @else if $match == 'contains' {
+    @return '[data-title*="#{$title}"]';
+  } @else {
+    @warn "code-title-icon: Unknown match type '#{$match}' for title '#{$title}'.";
+    @return '';
+  }
+}
+
+/**
+  * each config shall be a map containing:
+  *
+  * - title: the title to match
+  * - match: one of 'startsWith' 'endsWith' 'contains' 'equals'
+  * - icon: the icon url
+  */
+@mixin style($configs...) {
+  $selectors: ();
+
+  @each $config in $configs {
+    $title: map.get($config, 'title');
+    $match: map.get($config, 'match');
+    $icon: map.get($config, 'icon');
+    $selector: get-selector($title, $match);
+
+    @if $selector != '' {
+      $selectors: list.append($selectors, '&#{$selector}', comma);
+
+      .code-block-title-bar#{$selector}::before {
+        background-image: url('#{$icon}');
+      }
+    }
+  }
+
+  /* stylelint-disable-next-line order/order */
+  .code-block-title-bar {
+    #{$selectors} {
+      display: flex;
+      align-items: center;
+
+      &::before {
+        content: ' ';
+
+        display: inline-block;
+
+        width: 1.5em;
+        height: 1.5em;
+        margin-inline-end: 0.5em;
+
+        background-position: center;
+        background-size: contain;
+        background-repeat: no-repeat;
+      }
+    }
+  }
+}


### PR DESCRIPTION
E.g.:

```scss
@include code-title-icon.style(
  (
    title: ".vuepress/config.ts",
    match: "equals",
    icon: "https://theme-hope-assets.vuejs.press/logo.svg",
  ),
  (
    title: ".vuepress/client.ts",
    match: "equals",
    icon: "https://theme-hope-assets.vuejs.press/logo.svg",
  ),
  (
    title: ".vuepress/theme.ts",
    match: "equals",
    icon: "https://theme-hope-assets.vuejs.press/logo.svg",
  ),
  (
    title: ".scss",
    match: "endsWith",
    icon: "https://sass-lang.com/assets/img/logos/logo.svg",
  ),
  (
    title: ".md",
    match: "endsWith",
    icon: "https://theme-hope.vuejs.press/assets/image/markdown.svg",
  ),
  (
    title: ".vue",
    match: "endsWith",
    icon: "https://theme-hope.vuejs.press/assets/image/vue.svg",
  )
);
```