### PR TITLE
fix(plugin-docsearch): open on ctrl+k when page first loads

### DIFF
--- a/plugins/search/plugin-docsearch/src/client/composables/useDocSearchHotkeyListener.ts
+++ b/plugins/search/plugin-docsearch/src/client/composables/useDocSearchHotkeyListener.ts
@@ -4,19 +4,15 @@ import { useEventListener } from '@vueuse/core'
  * Add hotkey listener, remove it after triggered
  */
 export const useDocSearchHotkeyListener = (callback: () => void): void => {
-  useEventListener(
-    'keydown',
-    (event) => {
-      const isHotKeyBind = event.key === 'k' && (event.ctrlKey || event.metaKey)
-      const isSlashKey = event.key === '/'
+  useEventListener('keydown', (event) => {
+    const isHotKeyBind = event.key === 'k' && (event.ctrlKey || event.metaKey)
+    const isSlashKey = event.key === '/'
 
-      if (!isSlashKey && !isHotKeyBind) {
-        return
-      }
+    if (!isSlashKey && !isHotKeyBind) {
+      return
+    }
 
-      event.preventDefault()
-      callback()
-    },
-    { once: true },
-  )
+    event.preventDefault()
+    callback()
+  })
 }


### PR DESCRIPTION
The `{ once: true }` prevented the listener from properly attaching
and listening for a whole ctrl+k event. It would exit early, causing
the page to not function properly on first load.

`useEventListener` automatically removes itself on unmount, so I am not sure the purpose of this line. I am hopeful this is not intentional and simple mistake. By approving and merging this PR, you will greatly improve my quality of docs searching. Otherwise, I will need custom scripts :/.

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Other

### Description

The search feature now opens with ctrl+k consistently.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->

**Before**

https://github.com/user-attachments/assets/8ddc72b2-0172-4b51-9fc2-90dfc6193433

**After**

https://github.com/user-attachments/assets/0797b66e-459e-49e1-9be6-f78e90bf7dfa


--- 

The `before` branch adds the plugin inside the e2e thing. I am not sure if that is wanted. It requires some extra setup to test right now. I left that part out of this PR. 

I am hopeful that once this is merged in that ctrl+k will work on sites like https://www.nushell.sh! :D 