### PR TITLE
feat(helper): improve darkmode

### DIFF
--- a/plugins/markdown/plugin-markdown-chart/src/client/components/ChartJS.ts
+++ b/plugins/markdown/plugin-markdown-chart/src/client/components/ChartJS.ts
@@ -99,20 +99,15 @@ export default defineComponent({
     }
 
     onMounted(() => {
-      let pending: Promise<void> | null = null
-
       watchImmediate(
         __VUEPRESS_DEV__
           ? // config must be changed if type is changed, so no need to watch type
             [() => props.config, isDarkMode]
           : isDarkMode,
         async () => {
-          await pending
           destroyChart()
           await nextTick()
-          pending = renderChart()
-          await pending
-          pending = null
+          await renderChart()
           loaded.value = true
         },
         { flush: 'post' },

--- a/themes/theme-default/src/client/composables/useDarkMode.ts
+++ b/themes/theme-default/src/client/composables/useDarkMode.ts
@@ -1,13 +1,10 @@
 import { useData } from '@theme/useData'
+import { darkModeSymbol } from '@vuepress/helper/client'
 import { usePreferredDark, useStorage, watchImmediate } from '@vueuse/core'
-import type { InjectionKey, WritableComputedRef } from 'vue'
+import type { WritableComputedRef } from 'vue'
 import { computed, inject, onMounted, onUnmounted, provide } from 'vue'
 
 export type DarkModeRef = WritableComputedRef<boolean>
-
-export const darkModeSymbol: InjectionKey<DarkModeRef> = Symbol(
-  __VUEPRESS_DEV__ ? 'darkMode' : '',
-)
 
 const applyDarkModeToHTML = (isDarkMode: DarkModeRef): void => {
   const update = (value = isDarkMode.value): void => {
@@ -31,7 +28,7 @@ const applyDarkModeToHTML = (isDarkMode: DarkModeRef): void => {
  * Inject dark mode global computed
  */
 export const useDarkMode = (): DarkModeRef => {
-  const isDarkMode = inject(darkModeSymbol)
+  const isDarkMode = inject<WritableComputedRef<boolean>>(darkModeSymbol)
   if (!isDarkMode) {
     throw new Error('useDarkMode() is called without provider.')
   }

--- a/tools/helper/src/client/composables/useDarkMode.ts
+++ b/tools/helper/src/client/composables/useDarkMode.ts
@@ -1,31 +1,22 @@
-import { useMutationObserver } from '@vueuse/core'
 import type { Ref } from 'vue'
-import { onMounted, readonly, ref } from 'vue'
+import { readonly, ref } from 'vue'
 
 import { getDarkMode } from '../utils/index.js'
 
-let darkmode: Readonly<Ref<boolean>> | null = null
+const darkmode: Ref<boolean> = ref(false)
 
-const _useDarkMode = (): Readonly<Ref<boolean>> => {
-  const isDarkMode = ref(false)
+// Ensure darkmode is initialized only once in client-side
+if (typeof document !== 'undefined') {
+  darkmode.value = getDarkMode()
 
-  onMounted(() => {
-    isDarkMode.value = getDarkMode()
-
-    // Watch darkmode change
-    useMutationObserver(
-      document.documentElement,
-      () => {
-        isDarkMode.value = getDarkMode()
-      },
-      {
-        attributeFilter: ['data-theme'],
-        attributes: true,
-      },
-    )
+  const mutationObserver = new MutationObserver(() => {
+    darkmode.value = getDarkMode()
   })
 
-  return readonly(isDarkMode)
+  mutationObserver.observe(document.documentElement, {
+    attributeFilter: ['data-theme'],
+    attributes: true,
+  })
 }
 
 /**
@@ -35,6 +26,5 @@ const _useDarkMode = (): Readonly<Ref<boolean>> => {
  *
  * @returns Readonly darkmode ref / 只读的暗色模式响应式引用
  */
-// eslint-disable-next-line no-return-assign
-export const useDarkMode = (): Readonly<Ref<boolean>> =>
-  (darkmode ??= _useDarkMode())
+
+export const useDarkMode = (): Readonly<Ref<boolean>> => readonly(darkmode)

--- a/tools/helper/src/client/composables/useDarkMode.ts
+++ b/tools/helper/src/client/composables/useDarkMode.ts
@@ -1,9 +1,15 @@
-import type { Ref } from 'vue'
-import { readonly, ref } from 'vue'
+import type { ComputedRef, InjectionKey, Ref, WritableComputedRef } from 'vue'
+import { inject, readonly, ref } from 'vue'
 
 import { getDarkMode } from '../utils/index.js'
 
-const darkmode: Ref<boolean> = ref(false)
+export type DarkModeRef = Ref<boolean>
+
+export const darkModeSymbol: InjectionKey<
+  ComputedRef<boolean> | Ref<boolean> | WritableComputedRef<boolean>
+> = Symbol(__VUEPRESS_DEV__ ? 'darkMode' : '')
+
+const darkmode: DarkModeRef = ref(false)
 
 // Ensure darkmode is initialized only once in client-side
 if (typeof document !== 'undefined') {
@@ -27,4 +33,5 @@ if (typeof document !== 'undefined') {
  * @returns Readonly darkmode ref / 只读的暗色模式响应式引用
  */
 
-export const useDarkMode = (): Readonly<Ref<boolean>> => readonly(darkmode)
+export const useDarkMode = (): Readonly<Ref<boolean>> =>
+  readonly(inject(darkModeSymbol, darkmode))

--- a/tools/helper/tsconfig.build.json
+++ b/tools/helper/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "types": ["vuepress/client-types", "vite/client", "webpack-env"]
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
Now, themes are required to import `darkmodeSymbol` from `@vuepress/helper` and provides darkmode variable in root setup function.

This avoids plugins that need darkmode status always being initialized with `darkmode: false` then a possible update. 