### PR TITLE
Fixed import of @vuepress/plugin-markdown-chart

### DIFF
--- a/docs/plugins/markdown/markdown-chart/mermaid.md
+++ b/docs/plugins/markdown/markdown-chart/mermaid.md
@@ -105,7 +105,7 @@ Please see [mermaid](https://mermaid.js.org/).
 You can import and call `defineMermaidConfig` in [client config file][client-config] to customize mermaid:
 
 ```ts title=".vuepress/client.ts"
-import { defineMermaidConfig } from 'vuepress-plugin-md-enhance/client'
+import { defineMermaidConfig } from '@vuepress/plugin-markdown-chart/client'
 
 defineMermaidConfig({
   // mermaid options here


### PR DESCRIPTION
Fixed import of @vuepress/plugin-markdown-chart in docs example
