### PR TITLE
fix(plugin-slimsearch): fix search bug in plugin-slimsearch

### DIFF
--- a/plugins/search/plugin-slimsearch/src/client/components/SearchResult.ts
+++ b/plugins/search/plugin-slimsearch/src/client/components/SearchResult.ts
@@ -147,9 +147,13 @@ export default defineComponent({
         const formatterConfig =
           customFieldConfig[matchedItem.index] || '$content'
 
-        const [prefix, suffix = ''] = isPlainObject(formatterConfig)
-          ? formatterConfig[routeLocale.value].split('$content')
-          : formatterConfig.split('$content')
+        const rawFormatter = isPlainObject(formatterConfig)
+          ? (formatterConfig[routeLocale.value] ?? '$content')
+          : formatterConfig
+
+        const [prefix, suffix = ''] = (
+          isString(rawFormatter) ? rawFormatter : '$content'
+        ).split('$content')
 
         return matchedItem.display.map((display) =>
           h('div', getVNodes([prefix, ...display, suffix])),

--- a/plugins/search/plugin-slimsearch/src/client/composables/useSuggestions.ts
+++ b/plugins/search/plugin-slimsearch/src/client/composables/useSuggestions.ts
@@ -48,7 +48,7 @@ export const useSuggestions = (queries: Ref<string[]>): SuggestionsRef => {
             // oxlint-disable-next-line promise/prefer-await-to-callbacks
             .catch((err: unknown) => {
               // oxlint-disable-next-line no-console
-              console.error(err)
+              console.warn(err)
             })
         } else {
           suggestions.value = []


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Other

### Description

#### Bug 1 — `TypeError: n[f.value].split` is not a function in `SearchResult.ts`

When I type Chinese characters in the search box, it causes such an error:

<details><summary>Click to show error log</summary>

```
runtime-core.esm-bundler.js:4734 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'emitsOptions')
    at shouldUpdateComponent (runtime-core.esm-bundler.js:4734:27)
    at updateComponent (runtime-core.esm-bundler.js:6042:9)
    at processComponent (runtime-core.esm-bundler.js:5988:7)
    at patch (runtime-core.esm-bundler.js:5476:11)
    at patchKeyedChildren (runtime-core.esm-bundler.js:6396:9)
    at patchChildren (runtime-core.esm-bundler.js:6310:11)
    at patchElement (runtime-core.esm-bundler.js:5780:7)
    at processElement (runtime-core.esm-bundler.js:5614:9)
    at patch (runtime-core.esm-bundler.js:5464:11)
    at patchKeyedChildren (runtime-core.esm-bundler.js:6396:9)
runtime-core.esm-bundler.js:51 [Vue warn]: Unhandled error during execution of render function 
  at <RouteLink to="/programming/gobang/gobang4.html" onClick=fn<onClick> > 
  at <SearchResult queries=['五子棋'] isFocusing=false onClose=fn<onClose>  ... > 
  at <AsyncComponentWrapper queries=['五子棋'] isFocusing=false onClose=fn<onClose>  ... > 
  at <SearchModal> 
  at <Vuepress>
runtime-core.esm-bundler.js:51 [Vue warn]: Unhandled error during execution of component update 
  at <SearchResult queries=['五子棋'] isFocusing=false onClose=fn<onClose>  ... > 
  at <AsyncComponentWrapper queries=['五子棋'] isFocusing=false onClose=fn<onClose>  ... > 
  at <SearchModal> 
  at <Vuepress>
SearchResult-DMXpsPo3.js?v=6df20c53:2 Uncaught (in promise) TypeError: n[f.value].split is not a function
    at te (SearchResult-DMXpsPo…s?v=6df20c53:2:3332)
    at SearchResult-DMXpsPo…s?v=6df20c53:2:6479
    at runtime-core.esm-bundler.js:5241:31
    at Proxy.renderFnWithContext (runtime-core.esm-bundler.js:702:13)
    at Proxy.<anonymous> (utils-_b2e7bpk.js?v=6df20c53:179:19)
    at renderComponentRoot (runtime-core.esm-bundler.js:4558:16)
    at ReactiveEffect.componentUpdateFn [as fn] (runtime-core.esm-bundler.js:6118:46)
    at ReactiveEffect.run (reactivity.esm-bundler.js:239:19)
    at setupRenderEffect (runtime-core.esm-bundler.js:6253:5)
    at mountComponent (runtime-core.esm-bundler.js:6025:7)
```

</details> 

But it works well when typing English words.

https://github.com/vuepress/ecosystem/blob/2c4c5c961d29c261aeeef9ea43f8eb6911fbaf59/plugins/search/plugin-slimsearch/src/client/components/SearchResult.ts#L145-L160

In `getDisplay`, when a search result has `type: 'customField'` and the `formatter` option was configured as a locale-keyed object (e.g. `{ '/': 'Date: $content' }`), accessing `formatterConfig[routeLocale.value]` would return `undefined` (or a non-string) if the current locale path wasn't a key in that object. Calling `.split()` on that would crash.

**Fix**: Two-step safe access — first resolve the locale-specific formatter string (falling back to `'$content'` if the key is missing), then guard with `isString` before calling `.split`.

**Why only Chinese input triggers it**: Chinese text queries tend to match custom field content (dates, categories, etc. from frontmatter), which returns `customField`-type results. If the user's Chinese locale path (e.g. `/zh/`) isn't a key in the formatter config, the crash occurs. English queries often only match page content/headings.

#### Bug 2 — `console.error` for expected cancellation in `useSuggestions.ts`

https://github.com/vuepress/ecosystem/blob/2c4c5c961d29c261aeeef9ea43f8eb6911fbaf59/plugins/search/plugin-slimsearch/src/client/composables/useSuggestions.ts#L48-L52

https://github.com/vuepress/ecosystem/blob/2c4c5c961d29c261aeeef9ea43f8eb6911fbaf59/plugins/search/plugin-slimsearch/src/client/composables/useResults.ts#L47-L53

When typing quickly (especially with Chinese IME), each keystroke fires a new suggestion request that cancels the previous one. The catch handler for the cancelled promise was calling `console.error`, making every keystroke with Chinese input produce a red console error. Changed to `console.warn` to match the behaviour in `useResults.ts`.

### Screenshots

No UI changes.