### PR TITLE
fix(plugin-slimsearch): avoid crash when custom field formatter is no…

### DIFF
--- a/plugins/search/plugin-slimsearch/src/client/components/SearchResult.ts
+++ b/plugins/search/plugin-slimsearch/src/client/components/SearchResult.ts
@@ -145,11 +145,12 @@ export default defineComponent({
     const getDisplay = (matchedItem: MatchedItem): (VNode | string)[] => {
       if (matchedItem.type === 'customField') {
         const formatterConfig = customFieldConfig[matchedItem.index]
+        const formatter = isPlainObject(formatterConfig)
+          ? formatterConfig[routeLocale.value]
+          : formatterConfig
 
         const [prefix, suffix = ''] = (
-          (isPlainObject(formatterConfig)
-            ? formatterConfig[routeLocale.value]
-            : formatterConfig) ?? ''
+          isString(formatter) ? formatter : ''
         ).split('$content')
 
         return matchedItem.display.map((display) =>


### PR DESCRIPTION
…t a string

The search result renderer called .split('$content') on the resolved custom-field formatter. When the formatter is a per-locale record whose value for the current locale is missing or not a string, .split throws, corrupting the render tree and blanking the whole result panel.

Guard the resolved value with isString so a non-string formatter falls back to an empty template instead of throwing.

<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following <!-- (put an "X" next to an item) -->

- [x] Read the [Contributing Guidelines](https://github.com/vuepress/ecosystem/blob/main/CONTRIBUTING.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving. If this PR is going to solve an existing issue, please reference the issue (e.g. `close #123`).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New feature
- [ ] Other

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Screenshots

<!-- If your PR includes UI changes, please provide before/after screenshots. If there are any other images that add context to the PR, add them here as well -->

**Before**

**After**
