### PR TITLE
fix(plugin-pwa): correct shouldPrefetch warning condition

### DIFF
--- a/plugins/pwa/plugin-pwa/src/node/pwaPlugin.ts
+++ b/plugins/pwa/plugin-pwa/src/node/pwaPlugin.ts
@@ -47,7 +47,7 @@ export const pwaPlugin =
 
     if (options.appendBase) appendBase(base, options)
 
-    if (shouldPrefetch === true) {
+    if (shouldPrefetch !== false) {
       logger.warn(
         'The plugin will register service worker to handle assets, so we recommend you to set "shouldPrefetch: false" in VuePress config file.',
       )

--- a/plugins/pwa/plugin-pwa/src/node/pwaPlugin.ts
+++ b/plugins/pwa/plugin-pwa/src/node/pwaPlugin.ts
@@ -47,7 +47,7 @@ export const pwaPlugin =
 
     if (options.appendBase) appendBase(base, options)
 
-    if (shouldPrefetch !== true) {
+    if (shouldPrefetch === true) {
       logger.warn(
         'The plugin will register service worker to handle assets, so we recommend you to set "shouldPrefetch: false" in VuePress config file.',
       )


### PR DESCRIPTION
## Summary

- Fixed inverted condition in `@vuepress/plugin-pwa` that caused the `shouldPrefetch` warning to display incorrectly
- The warning was showing when `shouldPrefetch` was NOT true (including `false` and `undefined`), but it should only show when `shouldPrefetch` IS true (i.e., when prefetching is enabled)

## Changes

**File:** `plugins/pwa/plugin-pwa/src/node/pwaPlugin.ts`

```diff
- if (shouldPrefetch !== true) {
+ if (shouldPrefetch === true) {
```

## Problem

When users set `shouldPrefetch: false` in their VuePress config, they still received the warning:

```
@vuepress/plugin-pwa: ⚠ The plugin will register service worker to handle assets, so we recommend you to set "shouldPrefetch: false" in VuePress config file.
```

This is because the condition `shouldPrefetch !== true` evaluates to `true` for both `false` and `undefined`, causing the warning to always display unless `shouldPrefetch` is explicitly set to `true`.

## Solution

Changed the condition to `shouldPrefetch === true` so the warning only displays when prefetching is actually enabled (which is when users should be warned to disable it for PWA compatibility).

## Testing

- Verified the fix by checking that the warning now only appears when `shouldPrefetch: true` is set
- No existing unit tests for this warning behavior
