### PR TITLE
feat(plugin-docsearch): support docsearch v5

### DIFF
--- a/docs/plugins/search/docsearch.md
+++ b/docs/plugins/search/docsearch.md
@@ -203,12 +203,6 @@ If you are not using the default theme or encounter issues with search results, 
 - Also see:
   - [DocSearch > Options > indices](https://docsearch.algolia.com/docs/api#indices)
 
-::: tip indexName
-
-`indexName` as is shorthand for `indices` if you are only querying a single index. However, this is deprecated and will be removed in future versions. See [DocSearch > Options > indexName](https://docsearch.algolia.com/docs/api#indexname) for details.
-
-:::
-
 ### placeholder
 
 - Type: `string`

--- a/docs/zh/plugins/search/docsearch.md
+++ b/docs/zh/plugins/search/docsearch.md
@@ -200,12 +200,6 @@ new Crawler({
 - 参考：
   - [DocSearch > Options > indices](https://docsearch.algolia.com/docs/api#indices)
 
-::: tip indexName
-
-如果只使用单个索引，`indexName` 可以作为 `indices` 的简写，但它已经被弃用并会在未来版本中移除。详情请参阅 [DocSearch > Options > indexName](https://docsearch.algolia.com/docs/api#indexname)。
-
-:::
-
 ### placeholder
 
 - 类型：`string`

--- a/plugins/search/plugin-docsearch/package.json
+++ b/plugins/search/plugin-docsearch/package.json
@@ -48,15 +48,15 @@
     "clean": "rimraf ./dist"
   },
   "dependencies": {
-    "@docsearch/css": "^4.6.3",
-    "@docsearch/js": "^4.6.3",
+    "@docsearch/css": "^5.0.1",
+    "@docsearch/js": "^5.0.1",
     "@vuepress/helper": "workspace:*",
     "@vueuse/core": "catalog:",
     "ts-debounce": "^5.0.1",
     "vue": "catalog:"
   },
   "devDependencies": {
-    "@docsearch/react": "^4.6.3",
+    "@docsearch/react": "^5.0.1",
     "algoliasearch": "^5.56.0"
   },
   "peerDependencies": {

--- a/plugins/search/plugin-docsearch/src/client/components/DocSearch.ts
+++ b/plugins/search/plugin-docsearch/src/client/components/DocSearch.ts
@@ -55,18 +55,13 @@ export const DocSearch = defineComponent({
       if (__VUEPRESS_SSR__) return
 
       const { default: docsearch } = await import('@docsearch/js')
-      // oxlint-disable-next-line typescript/no-deprecated
-      const { indexName, indices, searchParameters, ...rest } = options.value
+      const { indices, ...rest } = options.value
 
       docsearch({
         ...docsearchShim,
         ...rest,
         container: `#${props.containerId}`,
-        indices: getIndices(
-          // oxlint-disable-next-line typescript/no-deprecated
-          { indices, indexName, searchParameters },
-          lang.value,
-        ),
+        indices: getIndices(indices, lang.value),
       })
       // mark as initialized
       hasInitialized.value = true

--- a/plugins/search/plugin-docsearch/src/client/composables/useDocSearchSlim.ts
+++ b/plugins/search/plugin-docsearch/src/client/composables/useDocSearchSlim.ts
@@ -36,7 +36,6 @@ export const useDocSearchShim = (): Partial<DocSearchProps> => {
     },
 
     // add search debounce
-    // @ts-expect-error: Return type of search is a type parameter
     transformSearchClient: (searchClient) => ({
       ...searchClient,
       search: debounce(searchClient.search, 500),

--- a/plugins/search/plugin-docsearch/src/client/styles/vars.scss
+++ b/plugins/search/plugin-docsearch/src/client/styles/vars.scss
@@ -9,7 +9,6 @@ html[data-theme='dark'] {
   --docsearch-modal-background: var(--vp-c-bg-elv);
   --docsearch-searchbox-background: var(--vp-c-grey-soft);
   --docsearch-searchbox-focus-background: var(--vp-c-bg-elv);
-  --docsearch-searchbox-shadow: inset 0 0 0 2px var(--vp-c-accent-soft);
   --docsearch-hit-color: var(--vp-c-text-mute);
   --docsearch-hit-highlight-color: var(--vp-c-accent-soft);
   --docsearch-footer-background: var(--vp-c-bg-alt);

--- a/plugins/search/plugin-docsearch/src/client/utils/getIndices.ts
+++ b/plugins/search/plugin-docsearch/src/client/utils/getIndices.ts
@@ -1,48 +1,41 @@
 import type { DocSearchIndex } from '@docsearch/react'
 import { isString } from 'vuepress/shared'
 
-import type { DocSearchOptions } from '../../shared/index.js'
 import { getFacetFiltersWithLang } from './getFacetFilters.js'
 
+/**
+ * Get indices with lang facet filters
+ *
+ * 获取带语言过滤条件的索引
+ *
+ * @param indices - DocSearch indices / DocSearch 索引
+ * @param lang - Current language / 当前语言
+ * @returns Indices with lang facet filters / 带语言过滤条件的索引
+ */
 export const getIndices = (
-  {
-    indices,
-    // oxlint-disable-next-line typescript/no-deprecated
-    indexName,
-    // oxlint-disable-next-line typescript/no-deprecated
-    searchParameters,
-  }: Pick<DocSearchOptions, 'indexName' | 'indices' | 'searchParameters'>,
+  indices: (DocSearchIndex | string)[],
   lang: string,
 ): DocSearchIndex[] =>
-  (
-    indices ?? [
-      {
-        name: indexName ?? '',
-        searchParameters,
-      },
-    ]
-  )
-    // oxlint-disable-next-line oxc/no-map-spread
-    .map((item) => {
-      if (isString(item)) {
-        return {
-          name: item,
-          searchParameters: {
-            facetFilters: `lang:${lang}`,
-          },
-        }
-      }
-
-      const { searchParameters: indexSearchParameters, ...rest } = item
-
+  indices.map((item) => {
+    if (isString(item)) {
       return {
-        ...rest,
+        name: item,
         searchParameters: {
-          ...indexSearchParameters,
-          facetFilters: getFacetFiltersWithLang(
-            lang,
-            indexSearchParameters?.facetFilters,
-          ),
+          facetFilters: `lang:${lang}`,
         },
       }
-    })
+    }
+
+    const { searchParameters: indexSearchParameters, ...rest } = item
+
+    return {
+      ...rest,
+      searchParameters: {
+        ...indexSearchParameters,
+        facetFilters: getFacetFiltersWithLang(
+          lang,
+          indexSearchParameters?.facetFilters,
+        ),
+      },
+    }
+  })

--- a/plugins/search/plugin-docsearch/src/node/locales.ts
+++ b/plugins/search/plugin-docsearch/src/node/locales.ts
@@ -16,22 +16,14 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: '搜索文档',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             clearButtonTitle: '清除查询条件',
             clearButtonAriaLabel: '清除查询条件',
             closeButtonText: '关闭',
             closeButtonAriaLabel: '关闭',
             placeholderText: '搜索文档',
-            placeholderTextAskAi: '向 AI 助手提问',
-            placeholderTextAskAiStreaming: '回答中...',
             searchInputLabel: '搜索',
-            backToKeywordSearchButtonText: '返回关键字搜索',
-            backToKeywordSearchButtonAriaLabel: '返回关键字搜索',
-            newConversationPlaceholder: '询问问题',
-            conversationHistoryTitle: '对话历史',
-            startNewConversationText: '新对话',
-            viewConversationHistoryText: '对话历史',
           },
           startScreen: {
             recentSearchesTitle: '搜索历史',
@@ -40,8 +32,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: '从搜索历史中移除',
             favoriteSearchesTitle: '收藏',
             removeFavoriteSearchButtonTitle: '从收藏中移除',
-            recentConversationsTitle: '最近对话',
-            removeRecentConversationButtonTitle: '从最近对话中移除',
           },
           errorScreen: {
             titleText: '无法获取结果',
@@ -52,26 +42,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             suggestedQueryText: '你可以尝试查询',
             reportMissingResultsText: '你认为该查询应该有结果？',
             reportMissingResultsLinkText: '告知我们',
-          },
-          resultsScreen: {
-            askAiPlaceholder: '询问AI：',
-            noResultsAskAiPlaceholder: '没有找到文档？让 AI 来帮忙：',
-          },
-          // @ts-expect-error: aggregatedTollCallNode and aggregatedTollCallText shall be remain default
-          askAiScreen: {
-            disclaimerText: 'AI 助手的回答可能不准确。自行验证回复。',
-            relatedSourcesText: '相关资源',
-            thinkingText: '思考中...',
-            copyButtonText: '复制',
-            copyButtonCopiedText: '已复制',
-            copyButtonTitle: '复制',
-            likeButtonTitle: '有帮助',
-            dislikeButtonTitle: '没帮助',
-            thanksForFeedbackText: '感谢您的反馈！',
-            preToolCallText: '搜索中...',
-            duringToolCallText: '搜索',
-            afterToolCallText: '已搜索',
-            stoppedStreamingText: '你停止了此回复',
           },
           footer: {
             selectText: '选择',
@@ -99,7 +69,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: '搜尋文件',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: '搜尋',
             clearButtonTitle: '清除查詢條件',
@@ -107,14 +77,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: '關閉',
             closeButtonAriaLabel: '關閉',
             placeholderText: '搜尋文件',
-            placeholderTextAskAi: '向 AI 助手提問',
-            placeholderTextAskAiStreaming: '回答中...',
-            backToKeywordSearchButtonText: '返回關鍵字搜尋',
-            backToKeywordSearchButtonAriaLabel: '返回關鍵字搜尋',
-            newConversationPlaceholder: '詢問問題',
-            conversationHistoryTitle: '對話歷史',
-            startNewConversationText: '新對話',
-            viewConversationHistoryText: '對話歷史',
           },
           startScreen: {
             recentSearchesTitle: '搜尋歷史',
@@ -123,8 +85,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: '從搜尋歷史中移除',
             favoriteSearchesTitle: '收藏',
             removeFavoriteSearchButtonTitle: '從收藏中移除',
-            recentConversationsTitle: '最近對話',
-            removeRecentConversationButtonTitle: '從最近對話中移除',
           },
           errorScreen: {
             titleText: '無法獲取結果',
@@ -162,7 +122,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Durchsuchen',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Suche',
             clearButtonTitle: 'Suchkriterien zurücksetzen',
@@ -170,14 +130,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Schließen',
             closeButtonAriaLabel: 'Schließen',
             placeholderText: 'Dokumentation durchsuchen',
-            placeholderTextAskAi: 'Frage den KI-Assistenten',
-            placeholderTextAskAiStreaming: 'Antwort wird generiert...',
-            backToKeywordSearchButtonText: 'Zurück zur Stichwortsuche',
-            backToKeywordSearchButtonAriaLabel: 'Zurück zur Stichwortsuche',
-            newConversationPlaceholder: 'Frage stellen',
-            conversationHistoryTitle: 'Unterhaltungsverlauf',
-            startNewConversationText: 'Neue Unterhaltung',
-            viewConversationHistoryText: 'Unterhaltungsverlauf',
           },
           startScreen: {
             recentSearchesTitle: 'Letzte Suchen',
@@ -186,9 +138,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Aus den letzten Suchen entfernen',
             favoriteSearchesTitle: 'Favoriten',
             removeFavoriteSearchButtonTitle: 'Aus den Favoriten entfernen',
-            recentConversationsTitle: 'Letzte Unterhaltungen',
-            removeRecentConversationButtonTitle:
-              'Aus den letzten Unterhaltungen entfernen',
           },
           errorScreen: {
             titleText: 'Keine Ergebnisse gefunden',
@@ -227,7 +176,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Tìm kiếm',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Tìm kiếm',
             clearButtonTitle: 'Xóa điều kiện tìm kiếm',
@@ -235,14 +184,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Đóng',
             closeButtonAriaLabel: 'Đóng',
             placeholderText: 'Tìm kiếm tài liệu',
-            placeholderTextAskAi: 'Hỏi trợ lý AI',
-            placeholderTextAskAiStreaming: 'Đang trả lời...',
-            backToKeywordSearchButtonText: 'Quay lại tìm kiếm từ khóa',
-            backToKeywordSearchButtonAriaLabel: 'Quay lại tìm kiếm từ khóa',
-            newConversationPlaceholder: 'Đặt câu hỏi',
-            conversationHistoryTitle: 'Lịch sử hội thoại',
-            startNewConversationText: 'Cuộc hội thoại mới',
-            viewConversationHistoryText: 'Lịch sử hội thoại',
           },
           startScreen: {
             recentSearchesTitle: 'Lịch sử tìm kiếm',
@@ -251,9 +192,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Xóa khỏi lịch sử tìm kiếm',
             favoriteSearchesTitle: 'Yêu thích',
             removeFavoriteSearchButtonTitle: 'Xóa khỏi yêu thích',
-            recentConversationsTitle: 'Cuộc hội thoại gần đây',
-            removeRecentConversationButtonTitle:
-              'Xóa khỏi cuộc hội thoại gần đây',
           },
           errorScreen: {
             titleText: 'Không tìm thấy kết quả',
@@ -291,7 +229,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Пошук',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Пошук',
             clearButtonTitle: 'Скинути умови пошуку',
@@ -299,16 +237,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Закрити',
             closeButtonAriaLabel: 'Закрити',
             placeholderText: 'Пошук документації',
-            placeholderTextAskAi: 'Поставити запитання AI-асистенту',
-            placeholderTextAskAiStreaming: 'Формується відповідь...',
-            backToKeywordSearchButtonText:
-              'Повернутися до пошуку за ключовими словами',
-            backToKeywordSearchButtonAriaLabel:
-              'Повернутися до пошуку за ключовими словами',
-            newConversationPlaceholder: 'Поставте запитання',
-            conversationHistoryTitle: 'Історія розмов',
-            startNewConversationText: 'Нова розмова',
-            viewConversationHistoryText: 'Історія розмов',
           },
           startScreen: {
             recentSearchesTitle: 'Останні пошуки',
@@ -317,8 +245,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Видалити з останніх пошуків',
             favoriteSearchesTitle: 'Обране',
             removeFavoriteSearchButtonTitle: 'Видалити з обраного',
-            recentConversationsTitle: 'Нещодавні розмови',
-            removeRecentConversationButtonTitle: 'Видалити з нещодавніх розмов',
           },
           errorScreen: {
             titleText: 'Немає результатів',
@@ -356,7 +282,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Поиск',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Поиск',
             clearButtonTitle: 'Сбросить условия поиска',
@@ -364,16 +290,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Закрыть',
             closeButtonAriaLabel: 'Закрыть',
             placeholderText: 'Поиск документации',
-            placeholderTextAskAi: 'Задайте вопрос ИИ-ассистенту',
-            placeholderTextAskAiStreaming: 'Формируется ответ...',
-            backToKeywordSearchButtonText:
-              'Вернуться к поиску по ключевым словам',
-            backToKeywordSearchButtonAriaLabel:
-              'Вернуться к поиску по ключевым словам',
-            newConversationPlaceholder: 'Задайте вопрос',
-            conversationHistoryTitle: 'История диалогов',
-            startNewConversationText: 'Новый диалог',
-            viewConversationHistoryText: 'История диалогов',
           },
           startScreen: {
             recentSearchesTitle: 'Последние запросы',
@@ -382,8 +298,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Удалить из последних запросов',
             favoriteSearchesTitle: 'Избранное',
             removeFavoriteSearchButtonTitle: 'Удалить из избранного',
-            recentConversationsTitle: 'Недавние диалоги',
-            removeRecentConversationButtonTitle: 'Удалить из недавних диалогов',
           },
           errorScreen: {
             titleText: 'Нет результатов',
@@ -421,7 +335,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Pesquisar',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Pesquisar',
             clearButtonTitle: 'Limpar critérios de pesquisa',
@@ -429,16 +343,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Fechar',
             closeButtonAriaLabel: 'Fechar',
             placeholderText: 'Pesquisar documentação',
-            placeholderTextAskAi: 'Pergunte ao assistente de IA',
-            placeholderTextAskAiStreaming: 'Respondendo...',
-            backToKeywordSearchButtonText:
-              'Voltar à pesquisa por palavra-chave',
-            backToKeywordSearchButtonAriaLabel:
-              'Voltar à pesquisa por palavra-chave',
-            newConversationPlaceholder: 'Faça uma pergunta',
-            conversationHistoryTitle: 'Histórico de conversas',
-            startNewConversationText: 'Nova conversa',
-            viewConversationHistoryText: 'Histórico de conversas',
           },
           startScreen: {
             recentSearchesTitle: 'Pesquisas recentes',
@@ -447,9 +351,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Remover das pesquisas recentes',
             favoriteSearchesTitle: 'Favoritos',
             removeFavoriteSearchButtonTitle: 'Remover dos favoritos',
-            recentConversationsTitle: 'Conversas recentes',
-            removeRecentConversationButtonTitle:
-              'Remover das conversas recentes',
           },
           errorScreen: {
             titleText: 'Nenhum resultado encontrado',
@@ -487,7 +388,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Szukaj',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Szukaj',
             clearButtonTitle: 'Wyczyść kryteria wyszukiwania',
@@ -495,16 +396,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Zamknij',
             closeButtonAriaLabel: 'Zamknij',
             placeholderText: 'Szukaj dokumentacji',
-            placeholderTextAskAi: 'Zadaj pytanie asystentowi AI',
-            placeholderTextAskAiStreaming: 'Odpowiedź w toku...',
-            backToKeywordSearchButtonText:
-              'Wróć do wyszukiwania słów kluczowych',
-            backToKeywordSearchButtonAriaLabel:
-              'Wróć do wyszukiwania słów kluczowych',
-            newConversationPlaceholder: 'Zadaj pytanie',
-            conversationHistoryTitle: 'Historia rozmów',
-            startNewConversationText: 'Nowa rozmowa',
-            viewConversationHistoryText: 'Historia rozmów',
           },
           startScreen: {
             recentSearchesTitle: 'Ostatnie wyszukiwania',
@@ -513,8 +404,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Usuń z ostatnich wyszukiwań',
             favoriteSearchesTitle: 'Ulubione',
             removeFavoriteSearchButtonTitle: 'Usuń z ulubionych',
-            recentConversationsTitle: 'Ostatnie rozmowy',
-            removeRecentConversationButtonTitle: 'Usuń z ostatnich rozmów',
           },
           errorScreen: {
             titleText: 'Brak wyników',
@@ -552,7 +441,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Hľadať',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Hľadať',
             clearButtonTitle: 'Vymazať kritériá vyhľadávania',
@@ -560,16 +449,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Zavrieť',
             closeButtonAriaLabel: 'Zavrieť',
             placeholderText: 'Hľadať dokumentáciu',
-            placeholderTextAskAi: 'Spýtať sa asistenta AI',
-            placeholderTextAskAiStreaming: 'Odpoveď sa generuje...',
-            backToKeywordSearchButtonText:
-              'Späť na vyhľadávanie kľúčových slov',
-            backToKeywordSearchButtonAriaLabel:
-              'Späť na vyhľadávanie kľúčových slov',
-            newConversationPlaceholder: 'Položte otázku',
-            conversationHistoryTitle: 'História konverzácií',
-            startNewConversationText: 'Nová konverzácia',
-            viewConversationHistoryText: 'História konverzácií',
           },
           startScreen: {
             recentSearchesTitle: 'Nedávne vyhľadávania',
@@ -578,9 +457,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Odstrániť z nedávnych vyhľadávaní',
             favoriteSearchesTitle: 'Obľúbené',
             removeFavoriteSearchButtonTitle: 'Odstrániť z obľúbených',
-            recentConversationsTitle: 'Nedávne konverzácie',
-            removeRecentConversationButtonTitle:
-              'Odstrániť z nedávnych konverzácií',
           },
           errorScreen: {
             titleText: 'Žiadne výsledky',
@@ -618,7 +494,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Rechercher',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Rechercher',
             clearButtonTitle: 'Réinitialiser les critères de recherche',
@@ -626,16 +502,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Fermer',
             closeButtonAriaLabel: 'Fermer',
             placeholderText: 'Rechercher dans la documentation',
-            placeholderTextAskAi: 'Poser une question à l’assistant IA',
-            placeholderTextAskAiStreaming: 'Réponse en cours...',
-            backToKeywordSearchButtonText:
-              'Retour à la recherche par mots-clés',
-            backToKeywordSearchButtonAriaLabel:
-              'Retour à la recherche par mots-clés',
-            newConversationPlaceholder: 'Poser une question',
-            conversationHistoryTitle: 'Historique des conversations',
-            startNewConversationText: 'Nouvelle conversation',
-            viewConversationHistoryText: 'Historique des conversations',
           },
           startScreen: {
             recentSearchesTitle: 'Recherches récentes',
@@ -645,9 +511,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Supprimer des recherches récentes',
             favoriteSearchesTitle: 'Favoris',
             removeFavoriteSearchButtonTitle: 'Supprimer des favoris',
-            recentConversationsTitle: 'Conversations récentes',
-            removeRecentConversationButtonTitle:
-              'Supprimer des conversations récentes',
           },
           errorScreen: {
             titleText: 'Aucun résultat',
@@ -686,7 +549,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Buscar',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Buscar',
             clearButtonTitle: 'Restablecer criterios de búsqueda',
@@ -694,16 +557,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Cerrar',
             closeButtonAriaLabel: 'Cerrar',
             placeholderText: 'Buscar documentación',
-            placeholderTextAskAi: 'Preguntar al asistente de IA',
-            placeholderTextAskAiStreaming: 'Respondiendo...',
-            backToKeywordSearchButtonText:
-              'Volver a la búsqueda por palabras clave',
-            backToKeywordSearchButtonAriaLabel:
-              'Volver a la búsqueda por palabras clave',
-            newConversationPlaceholder: 'Haz una pregunta',
-            conversationHistoryTitle: 'Historial de conversaciones',
-            startNewConversationText: 'Nueva conversación',
-            viewConversationHistoryText: 'Historial de conversaciones',
           },
           startScreen: {
             recentSearchesTitle: 'Búsquedas recientes',
@@ -712,9 +565,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Eliminar de búsquedas recientes',
             favoriteSearchesTitle: 'Favoritos',
             removeFavoriteSearchButtonTitle: 'Eliminar de favoritos',
-            recentConversationsTitle: 'Conversas recientes',
-            removeRecentConversationButtonTitle:
-              'Eliminar de conversaciones recientes',
           },
           errorScreen: {
             titleText: 'No se encontraron resultados',
@@ -752,7 +602,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: '検索',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: '検索',
             clearButtonTitle: '検索条件をリセット',
@@ -760,14 +610,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: '閉じる',
             closeButtonAriaLabel: '閉じる',
             placeholderText: 'ドキュメントを検索',
-            placeholderTextAskAi: 'AI アシスタントに質問する',
-            placeholderTextAskAiStreaming: '回答中...',
-            backToKeywordSearchButtonText: 'キーワード検索に戻る',
-            backToKeywordSearchButtonAriaLabel: 'キーワード検索に戻る',
-            newConversationPlaceholder: '質問を入力',
-            conversationHistoryTitle: '会話履歴',
-            startNewConversationText: '新しい会話',
-            viewConversationHistoryText: '会話履歴',
           },
           startScreen: {
             recentSearchesTitle: '最近の検索',
@@ -776,8 +618,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: '最近の検索から削除',
             favoriteSearchesTitle: 'お気に入り',
             removeFavoriteSearchButtonTitle: 'お気に入りから削除',
-            recentConversationsTitle: '最近の会話',
-            removeRecentConversationButtonTitle: '最近の会話から削除',
           },
           errorScreen: {
             titleText: '結果が見つかりません',
@@ -815,7 +655,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Ara',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Ara',
             clearButtonTitle: 'Arama kriterlerini sıfırla',
@@ -823,15 +663,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Kapat',
             closeButtonAriaLabel: 'Kapat',
             placeholderText: 'Belgeleri ara',
-            placeholderTextAskAi: 'AI asistanına soru sor',
-            placeholderTextAskAiStreaming: 'Yanıt oluşturuluyor...',
-            backToKeywordSearchButtonText: 'Anahtar kelime aramasına geri dön',
-            backToKeywordSearchButtonAriaLabel:
-              'Anahtar kelime aramasına geri dön',
-            newConversationPlaceholder: 'Soru sor',
-            conversationHistoryTitle: 'Sohbet geçmişi',
-            startNewConversationText: 'Yeni sohbet',
-            viewConversationHistoryText: 'Sohbet geçmişi',
           },
           startScreen: {
             recentSearchesTitle: 'Son Aramalar',
@@ -840,8 +671,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Son aramalardan kaldır',
             favoriteSearchesTitle: 'Favoriler',
             removeFavoriteSearchButtonTitle: 'Favorilerden kaldır',
-            recentConversationsTitle: 'Son sohbetler',
-            removeRecentConversationButtonTitle: 'Son sohbetlerden kaldır',
           },
           errorScreen: {
             titleText: 'Sonuç bulunamadı',
@@ -880,7 +709,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: '검색',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: '검색',
             clearButtonTitle: '검색 조건 초기화',
@@ -888,14 +717,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: '닫기',
             closeButtonAriaLabel: '닫기',
             placeholderText: '문서 검색',
-            placeholderTextAskAi: 'AI 도우미에게 질문하기',
-            placeholderTextAskAiStreaming: '답변 중...',
-            backToKeywordSearchButtonText: '키워드 검색으로 돌아가기',
-            backToKeywordSearchButtonAriaLabel: '키워드 검색으로 돌아가기',
-            newConversationPlaceholder: '질문하기',
-            conversationHistoryTitle: '대화 기록',
-            startNewConversationText: '새 대화',
-            viewConversationHistoryText: '대화 기록',
           },
           startScreen: {
             recentSearchesTitle: '최근 검색',
@@ -904,8 +725,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: '최근 검색에서 제거',
             favoriteSearchesTitle: '즐겨찾기',
             removeFavoriteSearchButtonTitle: '즐겨찾기에서 제거',
-            recentConversationsTitle: '최근 대화',
-            removeRecentConversationButtonTitle: '최근 대화에서 제거',
           },
           errorScreen: {
             titleText: '결과를 찾을 수 없습니다',
@@ -943,7 +762,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Hae',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Hae',
             clearButtonTitle: 'Nollaa hakuehdot',
@@ -951,14 +770,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Sulje',
             closeButtonAriaLabel: 'Sulje',
             placeholderText: 'Hae dokumentaatiosta',
-            placeholderTextAskAi: 'Kysy AI-avustajalta',
-            placeholderTextAskAiStreaming: 'Vastataan...',
-            backToKeywordSearchButtonText: 'Takaisin avainsanahakuun',
-            backToKeywordSearchButtonAriaLabel: 'Takaisin avainsanahakuun',
-            newConversationPlaceholder: 'Esitä kysymys',
-            conversationHistoryTitle: 'Keskusteluhistoria',
-            startNewConversationText: 'Uusi keskustelu',
-            viewConversationHistoryText: 'Keskusteluhistoria',
           },
           startScreen: {
             recentSearchesTitle: 'Viimeisimmät haut',
@@ -967,9 +778,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Poista viimeisimmistä hauista',
             favoriteSearchesTitle: 'Suosikit',
             removeFavoriteSearchButtonTitle: 'Poista suosikeista',
-            recentConversationsTitle: 'Viimeisimmät keskustelut',
-            removeRecentConversationButtonTitle:
-              'Poista viimeisimmistä keskusteluista',
           },
           errorScreen: {
             titleText: 'Ei tuloksia',
@@ -1007,7 +815,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Keresés',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Keresés',
             clearButtonTitle: 'Keresési feltételek visszaállítása',
@@ -1015,15 +823,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Bezárás',
             closeButtonAriaLabel: 'Bezárás',
             placeholderText: 'Dokumentáció keresése',
-            placeholderTextAskAi: 'Kérdezzen az AI asszisztenstől',
-            placeholderTextAskAiStreaming: 'Válasz folyamatban...',
-            backToKeywordSearchButtonText: 'Vissza a kulcsszavas kereséshez',
-            backToKeywordSearchButtonAriaLabel:
-              'Vissza a kulcsszavas kereséshez',
-            newConversationPlaceholder: 'Tegyen fel kérdést',
-            conversationHistoryTitle: 'Beszélgetések előzményei',
-            startNewConversationText: 'Új beszélgetés',
-            viewConversationHistoryText: 'Beszélgetések előzményei',
           },
           startScreen: {
             recentSearchesTitle: 'Legutóbbi keresések',
@@ -1033,9 +832,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
               'Eltávolítás a legutóbbi keresésekből',
             favoriteSearchesTitle: 'Kedvencek',
             removeFavoriteSearchButtonTitle: 'Eltávolítás a kedvencekből',
-            recentConversationsTitle: 'Legutóbbi beszélgetések',
-            removeRecentConversationButtonTitle:
-              'Eltávolítás a legutóbbi beszélgetésekből',
           },
           errorScreen: {
             titleText: 'Nincs találat',
@@ -1074,7 +870,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Cari',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Cari',
             clearButtonTitle: 'Atur ulang kriteria pencarian',
@@ -1082,15 +878,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Tutup',
             closeButtonAriaLabel: 'Tutup',
             placeholderText: 'Cari dokumentasi',
-            placeholderTextAskAi: 'Tanyakan ke asisten AI',
-            placeholderTextAskAiStreaming: 'Sedang menjawab...',
-            backToKeywordSearchButtonText: 'Kembali ke pencarian kata kunci',
-            backToKeywordSearchButtonAriaLabel:
-              'Kembali ke pencarian kata kunci',
-            newConversationPlaceholder: 'Ajukan pertanyaan',
-            conversationHistoryTitle: 'Riwayat percakapan',
-            startNewConversationText: 'Percakapan baru',
-            viewConversationHistoryText: 'Riwayat percakapan',
           },
           startScreen: {
             recentSearchesTitle: 'Pencarian terbaru',
@@ -1099,9 +886,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             removeRecentSearchButtonTitle: 'Hapus dari pencarian terbaru',
             favoriteSearchesTitle: 'Favorit',
             removeFavoriteSearchButtonTitle: 'Hapus dari favorit',
-            recentConversationsTitle: 'Percakapan terbaru',
-            removeRecentConversationButtonTitle:
-              'Hapus dari percakapan terbaru',
           },
           errorScreen: {
             titleText: 'Tidak ada hasil',
@@ -1139,7 +923,7 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
           buttonAriaLabel: 'Zoeken',
         },
         modal: {
-          // @ts-expect-error: enterKeyHint and enterKeyHintAskAi do not need to be provided per locale
+          // @ts-expect-error: enterKeyHint do not need to be provided per locale
           searchBox: {
             searchInputLabel: 'Zoeken',
             clearButtonTitle: 'Zoekcriteria resetten',
@@ -1147,15 +931,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
             closeButtonText: 'Sluiten',
             closeButtonAriaLabel: 'Sluiten',
             placeholderText: 'Documentatie doorzoeken',
-            placeholderTextAskAi: 'Stel een vraag aan de AI-assistent',
-            placeholderTextAskAiStreaming: 'Antwoord wordt gegenereerd...',
-            backToKeywordSearchButtonText: 'Terug naar zoeken op trefwoord',
-            backToKeywordSearchButtonAriaLabel:
-              'Terug naar zoeken op trefwoord',
-            newConversationPlaceholder: 'Stel een vraag',
-            conversationHistoryTitle: 'Gespreksgeschiedenis',
-            startNewConversationText: 'Nieuw gesprek',
-            viewConversationHistoryText: 'Gespreksgeschiedenis',
           },
           startScreen: {
             recentSearchesTitle: 'Recente zoekopdrachten',
@@ -1165,9 +940,6 @@ export const docSearchLocaleInfo: DefaultLocaleInfo<DocSearchLocaleData> = [
               'Verwijderen uit recente zoekopdrachten',
             favoriteSearchesTitle: 'Favorieten',
             removeFavoriteSearchButtonTitle: 'Verwijderen uit favorieten',
-            recentConversationsTitle: 'Conversas recentes',
-            removeRecentConversationButtonTitle:
-              'Verwijderen uit conversas recentes',
           },
           errorScreen: {
             titleText: 'Geen resultaten gevonden',

--- a/plugins/search/plugin-docsearch/src/shared/options.ts
+++ b/plugins/search/plugin-docsearch/src/shared/options.ts
@@ -11,16 +11,11 @@ export type DocSearchLocaleOptions = Partial<
     DocSearchProps,
     | 'apiKey'
     | 'appId'
-    | 'askAi'
     | 'disableUserPersonalization'
-    /** @deprecated use `indices` instead */
-    | 'indexName'
     | 'indices'
     | 'initialQuery'
     | 'maxResultsPerGroup'
     | 'placeholder'
-    /** @deprecated use `indices` instead */
-    | 'searchParameters'
     | 'translations'
   >
 >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,7 +355,7 @@ importers:
         version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.50.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.2.0)(@vitest/coverage-istanbul@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.50.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/coverage-istanbul@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.50.0)(yaml@2.9.0))
       vuepress:
         specifier: 'catalog:'
         version: 2.0.0-rc.30(dac08a144f87e39c53a5e90c96103cc7)
@@ -1447,11 +1447,11 @@ importers:
   plugins/search/plugin-docsearch:
     dependencies:
       '@docsearch/css':
-        specifier: ^4.6.3
-        version: 4.7.0
+        specifier: ^5.0.1
+        version: 5.0.1
       '@docsearch/js':
-        specifier: ^4.6.3
-        version: 4.7.0
+        specifier: ^5.0.1
+        version: 5.0.1(@algolia/client-search@5.56.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)
       '@vuepress/helper':
         specifier: workspace:*
         version: link:../../../tools/helper
@@ -1469,8 +1469,8 @@ importers:
         version: 2.0.0-rc.30(dac08a144f87e39c53a5e90c96103cc7)
     devDependencies:
       '@docsearch/react':
-        specifier: ^4.6.3
-        version: 4.7.0(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
+        specifier: ^5.0.1
+        version: 5.0.1(@algolia/client-search@5.56.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)
       algoliasearch:
         specifier: ^5.56.0
         version: 5.56.0
@@ -1870,6 +1870,32 @@ importers:
         version: 7.8.0
 
 packages:
+
+  '@ai-sdk/gateway@2.0.131':
+    resolution: {integrity: sha512-9PamvB9FzqTtrXJZ0fXWRYbSrImxU72l7jAMJEo0Zyeq+k5fl/YyuTBiZhppOHQIw09Dt5lyQp/N4DswGnDyrg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.32':
+    resolution: {integrity: sha512-izgUo50kamJMwoYCXoFwVccuJeyYp0y1+twf0FfpEz7kdQBloZLZbgLYUOUpannLWrV7xYSJR48BQJIQFbFiAQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@2.0.236':
+    resolution: {integrity: sha512-2WzeqL16YcuBBJ2ihCuw2fy60Mdwti6nJ/vO9ByZDcbHHfpPv1N7Xq4Ou0qejnDyWCKw5d1ECUSQlUiJauFn7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
+      zod: ^3.25.76 || ^4.1.8
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@algolia/abtesting@1.22.0':
     resolution: {integrity: sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==}
@@ -2472,6 +2498,33 @@ packages:
     resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
@@ -2550,8 +2603,8 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.1.1
 
-  '@docsearch/core@4.7.0':
-    resolution: {integrity: sha512-p/9xVKmPDj3FPvMfPf5naVO3Ej8SCbcUugGvx1+8GgkuBNbqxqN2Irx3WLBv8VY0jH7XpRwKWdlmjXLZsmTLsg==}
+  '@docsearch/core@5.0.1':
+    resolution: {integrity: sha512-2iQ8m9eqGhiSvxt+CotLLqCNxE36K3ks0ALXiirTdr09HKBzt2RKi+m9bMA911rXxWO2NCq9Ug8LJxCCB3XmNQ==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 20.0.0'
       react: '>= 16.8.0 < 20.0.0'
@@ -2564,14 +2617,14 @@ packages:
       react-dom:
         optional: true
 
-  '@docsearch/css@4.7.0':
-    resolution: {integrity: sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==}
+  '@docsearch/css@5.0.1':
+    resolution: {integrity: sha512-q1HdKMkROnZIIN+/eSa2f6qtIn9VcBtXelVMScFuWTWPQwIMBt0evl/TJku0HsssMJkuT6jKzY6Yfet/RMG2Tg==}
 
-  '@docsearch/js@4.7.0':
-    resolution: {integrity: sha512-x5lCqu1tetgsJFkjQ6VSocbHldsRkGEgwg5N98Vx21sq/V5wcmj4u226PY9k+TEpIgQ772zlYbPLTPicWyGnpA==}
+  '@docsearch/js@5.0.1':
+    resolution: {integrity: sha512-MPhohJzaTcbHpShOg7Xg2lck+URCv8XnHHr9kV9MTdXM3BVEXLzoaH7VPAZnaQ4jl3Q0diwLgspd9FnTDRxnsQ==}
 
-  '@docsearch/react@4.7.0':
-    resolution: {integrity: sha512-x6oedjJ8O8/pIDBsMo5Orca3/6cQCz616/CwthVe68l43mqnj2lrJ9kFQITBqy8hMsS3nWeBWFoVO5dJ1DCFKA==}
+  '@docsearch/react@5.0.1':
+    resolution: {integrity: sha512-0gP+NZxQDNltW72LQiqTjmKMf0lffOY7UJndll8js9zhRvgfucs7iGaBJyQdP/wZL+4jeUskjyWspjSO1KbVbg==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 20.0.0'
       react: '>= 16.8.0 < 20.0.0'
@@ -2902,11 +2955,24 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
   '@floating-ui/core@1.8.0':
     resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
 
   '@floating-ui/dom@1.1.1':
     resolution: {integrity: sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
@@ -3720,6 +3786,10 @@ packages:
 
   '@octokit/types@17.0.0':
     resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.143.0':
     resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
@@ -4811,6 +4881,10 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-vue@6.0.8':
     resolution: {integrity: sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5168,6 +5242,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@5.0.233:
+    resolution: {integrity: sha512-pn/4lYxGsPt9J5Z35WwGMhrcmOVBPkEn39SUdrKlYumeYDPl5SSnkoCbut7VDQSpAy1TTHVFJ302k/fg/pSLpQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -6360,6 +6440,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -7208,6 +7292,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stringify-nice@1.1.4:
     resolution: {integrity: sha512-5Z5RFW63yxReJ7vANgW6eZFGWaQvnPE3WNmZoOJrSkGju2etKA2L5rrOa1sm877TVTFt57A80BH1bArcmlLfPw==}
@@ -8705,6 +8792,15 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
+
   read-cmd-shim@6.0.0:
     resolution: {integrity: sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -8810,6 +8906,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -9072,6 +9171,9 @@ packages:
   sax@1.6.1:
     resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
     engines: {node: '>=11.0.0'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
@@ -9501,6 +9603,11 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  swr@2.5.0:
+    resolution: {integrity: sha512-W0GomadRJe9OfzIoRX0kZHhDSaRRfdiOUeH6uazgR05SibBhDNwfdTbhAxmFtObvkf59fFymo22mooKukosvNA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   sync-child-process@1.0.2:
     resolution: {integrity: sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==}
     engines: {node: '>=16.0.0'}
@@ -9543,6 +9650,10 @@ packages:
     engines: {node: '>=10.18'}
     peerDependencies:
       tslib: ^2
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
@@ -9732,6 +9843,10 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
   undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
@@ -9859,6 +9974,11 @@ packages:
 
   update-check@1.5.4:
     resolution: {integrity: sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -10317,6 +10437,9 @@ packages:
   zeptomatch@2.1.0:
     resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zrender@5.6.1:
     resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
 
@@ -10327,6 +10450,35 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ai-sdk/gateway@2.0.131(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.32(zod@4.4.3)
+      '@vercel/oidc': 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@3.0.32(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.1
+      undici: 5.29.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@2.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@2.0.236(react@19.2.8)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider-utils': 3.0.32(zod@4.4.3)
+      ai: 5.0.233(zod@4.4.3)
+      react: 19.2.8
+      swr: 2.5.0(react@19.2.8)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 4.4.3
 
   '@algolia/abtesting@1.22.0':
     dependencies:
@@ -11130,6 +11282,25 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.4
 
+  '@base-ui/react@1.7.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
+  '@base-ui/utils@0.3.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
   '@braintree/sanitize-url@7.1.2': {}
 
   '@bufbuild/protobuf@2.13.0': {}
@@ -11189,22 +11360,45 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.5
 
-  '@docsearch/core@4.7.0': {}
-
-  '@docsearch/css@4.7.0': {}
-
-  '@docsearch/js@4.7.0': {}
-
-  '@docsearch/react@4.7.0(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)':
-    dependencies:
-      '@algolia/autocomplete-core': 1.19.2(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
-      '@docsearch/core': 4.7.0
-      '@docsearch/css': 4.7.0
+  '@docsearch/core@5.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  '@docsearch/css@5.0.1': {}
+
+  '@docsearch/js@5.0.1(@algolia/client-search@5.56.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)':
+    dependencies:
+      '@docsearch/core': 5.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@docsearch/react': 5.0.1(@algolia/client-search@5.56.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@date-fns/tz'
+      - '@types/react'
+      - date-fns
+      - react
+      - react-dom
+      - search-insights
+
+  '@docsearch/react@5.0.1(@algolia/client-search@5.56.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)':
+    dependencies:
+      '@ai-sdk/react': 2.0.236(react@19.2.8)(zod@4.4.3)
+      '@algolia/autocomplete-core': 1.19.2(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
+      '@base-ui/react': 1.7.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@docsearch/core': 5.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@docsearch/css': 5.0.1
+      ai: 5.0.233(zod@4.4.3)
+      algoliasearch: 5.56.0
+      marked: 16.4.2
+      zod: 4.4.3
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - '@algolia/client-search'
-      - algoliasearch
+      - '@date-fns/tz'
+      - date-fns
 
   '@epic-web/invariant@1.0.0': {}
 
@@ -11364,6 +11558,8 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
+  '@fastify/busboy@2.1.1': {}
+
   '@floating-ui/core@1.8.0':
     dependencies:
       '@floating-ui/utils': 0.2.12
@@ -11371,6 +11567,17 @@ snapshots:
   '@floating-ui/dom@1.1.1':
     dependencies:
       '@floating-ui/core': 1.8.0
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   '@floating-ui/utils@0.2.12': {}
 
@@ -12254,6 +12461,8 @@ snapshots:
   '@octokit/types@17.0.0':
     dependencies:
       '@octokit/openapi-types': 28.0.0
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@oxc-project/types@0.143.0': {}
 
@@ -13163,6 +13372,8 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vitejs/plugin-vue@6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -13181,7 +13392,7 @@ snapshots:
       magicast: 0.5.4
       obug: 2.1.4
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@26.2.0)(@vitest/coverage-istanbul@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.50.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/coverage-istanbul@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.50.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -13752,6 +13963,14 @@ snapshots:
   acorn@8.18.0: {}
 
   agent-base@7.1.4: {}
+
+  ai@5.0.233(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 2.0.131(zod@4.4.3)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.32(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
@@ -15119,6 +15338,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.1: {}
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -16018,6 +16239,8 @@ snapshots:
   json-parse-even-better-errors@5.0.0: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   json-stringify-nice@1.1.4: {}
 
@@ -17633,6 +17856,13 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
+  react@19.2.8: {}
+
   read-cmd-shim@6.0.0: {}
 
   readable-stream@2.3.8:
@@ -17779,6 +18009,8 @@ snapshots:
   require-from-string@2.0.2: {}
 
   requires-port@1.0.0: {}
+
+  reselect@5.2.0: {}
 
   resolve-cwd@3.0.0:
     dependencies:
@@ -18040,6 +18272,8 @@ snapshots:
       '@parcel/watcher': 2.6.0
 
   sax@1.6.1: {}
+
+  scheduler@0.27.0: {}
 
   schema-utils@4.3.3:
     dependencies:
@@ -18604,6 +18838,12 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.1
 
+  swr@2.5.0(react@19.2.8):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
   sync-child-process@1.0.2:
     dependencies:
       sync-message-port: 1.2.0
@@ -18651,6 +18891,8 @@ snapshots:
   thingies@2.6.1(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
+
+  throttleit@2.1.0: {}
 
   thunky@1.1.0: {}
 
@@ -18826,6 +19068,10 @@ snapshots:
 
   undici-types@8.3.0: {}
 
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
   undici@6.28.0: {}
 
   undici@7.29.0: {}
@@ -18930,6 +19176,10 @@ snapshots:
       registry-auth-token: 3.3.2
       registry-url: 3.1.0
 
+  use-sync-external-store@1.6.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
   util-deprecate@1.0.2: {}
 
   utila@0.4.0: {}
@@ -18980,7 +19230,7 @@ snapshots:
       terser: 5.50.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.2.0)(@vitest/coverage-istanbul@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.50.0)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/coverage-istanbul@4.1.10)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.50.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.50.0)(yaml@2.9.0))
@@ -19003,6 +19253,7 @@ snapshots:
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.102.0)(terser@5.50.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 26.2.0
       '@vitest/coverage-istanbul': 4.1.10(supports-color@10.2.2)(vitest@4.1.10)
     transitivePeerDependencies:
@@ -19525,6 +19776,8 @@ snapshots:
     dependencies:
       grammex: 3.1.13
       graphmatch: 1.1.1
+
+  zod@4.4.3: {}
 
   zrender@5.6.1:
     dependencies:


### PR DESCRIPTION
## Summary

Upgrade `@docsearch/css`, `@docsearch/js` and `@docsearch/react` to **v5** for `@vuepress/plugin-docsearch`.

## Breaking changes from docsearch v5

- The deprecated top-level `indexName` and `searchParameters` options are removed. Use `indices` instead.
- The deprecated `askAi` option is removed (Ask AI has been migrated to Algolia Agent Studio).
- `appId`, `apiKey` and `indices` are now required.

## Changes

- Bump `@docsearch/css` and `@docsearch/js` to `^5.0.1`, `@docsearch/react` (dev) to `^5.0.1`
- Remove deprecated `indexName`, `searchParameters` and `askAi` options from plugin options
- Simplify `getIndices` since `indices` is now required
- Remove Ask AI related locale translations (removed in v5)
- Remove unused `--docsearch-searchbox-shadow` CSS variable
- Update docs to drop the `indexName` tip
