### PR TITLE
feat(plugin-markdown-field): add field container

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![license](https://badgen.net/github/license/vuepress/ecosystem)](https://github.com/vuepress/ecosystem/blob/main/LICENSE)
 [![discord](https://badgen.net/discord/online-members/ptFjefy6H5?icon=discord&label=discord)](https://discord.gg/ptFjefy6H5)
 
-This repo contains 48 official plugins and 1 official theme.
+This repo contains 57 official plugins and 1 official theme.
 
 ## Documentation
 

--- a/docs/.vuepress/configs/plugins.ts
+++ b/docs/.vuepress/configs/plugins.ts
@@ -8,6 +8,7 @@ import { iconPlugin } from '@vuepress/plugin-icon'
 import { llmsPlugin } from '@vuepress/plugin-llms'
 import { markdownChartPlugin } from '@vuepress/plugin-markdown-chart'
 import { markdownExtPlugin } from '@vuepress/plugin-markdown-ext'
+import { markdownFieldPlugin } from '@vuepress/plugin-markdown-field'
 import { markdownFileTreePlugin } from '@vuepress/plugin-markdown-file-tree'
 import { markdownImagePlugin } from '@vuepress/plugin-markdown-image'
 import { markdownIncludePlugin } from '@vuepress/plugin-markdown-include'
@@ -66,6 +67,9 @@ export const plugins = [
     gfm: true,
     component: true,
     vPre: true,
+  }),
+  markdownFieldPlugin({
+    fields: true,
   }),
   markdownFileTreePlugin(),
   markdownImagePlugin({

--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -125,6 +125,7 @@ export const sidebarEn: SidebarOptions = {
     },
     'markdown-container',
     'markdown-ext',
+    'markdown-field',
     'markdown-file-tree',
     'markdown-image',
     'markdown-include',

--- a/docs/.vuepress/configs/sidebar/zh.ts
+++ b/docs/.vuepress/configs/sidebar/zh.ts
@@ -125,6 +125,7 @@ export const sidebarZh: SidebarOptions = {
     },
     'markdown-container',
     'markdown-ext',
+    'markdown-field',
     'markdown-file-tree',
     'markdown-image',
     'markdown-include',

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,6 +28,7 @@
     "@vuepress/plugin-llms": "workspace:*",
     "@vuepress/plugin-markdown-chart": "workspace:*",
     "@vuepress/plugin-markdown-ext": "workspace:*",
+    "@vuepress/plugin-markdown-field": "workspace:*",
     "@vuepress/plugin-markdown-file-tree": "workspace:*",
     "@vuepress/plugin-markdown-image": "workspace:*",
     "@vuepress/plugin-markdown-include": "workspace:*",

--- a/docs/plugins/markdown/markdown-field.md
+++ b/docs/plugins/markdown/markdown-field.md
@@ -1,0 +1,131 @@
+---
+icon: list-checks
+---
+
+# markdown-field
+
+<NpmBadge package="@vuepress/plugin-markdown-field" />
+
+Add fields to your VuePress site.
+
+## Usage
+
+```bash
+npm i -D @vuepress/plugin-markdown-field@next
+```
+
+```ts title=".vuepress/config.ts"
+import { markdownFieldPlugin } from '@vuepress/plugin-markdown-field'
+
+export default {
+  plugins: [
+    markdownFieldPlugin({
+      // Enable fields
+      fields: true,
+    }),
+  ],
+}
+```
+
+## Syntax
+
+You can use `::: fields` container to describe field information, including field name, type, whether it's required, default value, etc.
+
+Inside the container, lines starting with `@name@` are field items. Attributes are appended after the closing `@`.
+
+```md
+::: fields
+@theme@ type="ThemeConfig" required default="{ base: '/' }"
+
+Theme Config
+
+@enabled@ type="boolean" optional default="true"
+
+Whether it's enabled
+
+:::
+```
+
+By default, all attributes are allowed and displayed as-is. Common attributes include `type`, `required`, `optional`, `default` and `deprecated`.
+
+- `type` is displayed as a code block in the field header.
+- `default` is displayed as a labeled code block below the field header.
+- `required`, `optional` and `deprecated` are displayed as badges, and a deprecated field's name is colored red and struck through.
+- Other attributes are displayed as `Name: value` badges.
+
+### Nesting
+
+Fields can be nested to describe fields of an object type. To create a field item inside another field, increase the starting `@` by one for each level of nesting.
+
+```md
+::: fields
+@options@ type="object"
+
+Options.
+
+@@options.name@ type="string"
+
+Option name.
+
+@other@ type="string"
+
+Other field.
+
+:::
+```
+
+For more syntax details, see [@mdit/plugin-field](https://mdit-plugins.github.io/field.html).
+
+## Demo
+
+::: fields
+@theme@ type="ThemeConfig" required default="{ base: '/' }"
+
+Theme Config
+
+@enabled@ type="boolean" optional default="true"
+
+Whether it's enabled
+
+@other@ type="string" deprecated
+
+Deprecated field
+
+:::
+
+## Options
+
+### fields
+
+- Type: `boolean`
+- Details: Whether to enable fields.
+
+### locales
+
+- Type: `MarkdownFieldPluginLocaleConfig`
+
+```ts
+interface MarkdownFieldPluginLocaleData {
+  /**
+   * Label text for the `default` attribute
+   */
+  default: string
+
+  /**
+   * Badge text for the `required` attribute
+   */
+  required: string
+
+  /**
+   * Badge text for the `optional` attribute
+   */
+  optional: string
+
+  /**
+   * Badge text for the `deprecated` attribute
+   */
+  deprecated: string
+}
+```
+
+- Details: Locale config for badge texts.

--- a/docs/zh/plugins/markdown/markdown-field.md
+++ b/docs/zh/plugins/markdown/markdown-field.md
@@ -1,0 +1,131 @@
+---
+icon: list-checks
+---
+
+# markdown-field
+
+<NpmBadge package="@vuepress/plugin-markdown-field" />
+
+在 VuePress 站点中添加字段容器。
+
+## 使用
+
+```bash
+npm i -D @vuepress/plugin-markdown-field@next
+```
+
+```ts title=".vuepress/config.ts"
+import { markdownFieldPlugin } from '@vuepress/plugin-markdown-field'
+
+export default {
+  plugins: [
+    markdownFieldPlugin({
+      // 启用字段容器
+      fields: true,
+    }),
+  ],
+}
+```
+
+## 语法
+
+你可以使用 `::: fields` 容器描述字段信息，包括字段名称、类型、是否必填、默认值等。
+
+在容器内部，以 `@名称@` 开头的行是字段项目。属性附加在闭合的 `@` 之后。
+
+```md
+::: fields
+@theme@ type="ThemeConfig" required default="{ base: '/' }"
+
+主题配置
+
+@enabled@ type="boolean" optional default="true"
+
+是否启用
+
+:::
+```
+
+默认情况下，所有属性都允许并按原样显示。常见属性包括 `type`、`required`、`optional`、`default` 和 `deprecated`。
+
+- `type` 显示为字段头部中的代码块。
+- `default` 显示为字段头部下方带标签的代码块。
+- `required`、`optional` 和 `deprecated` 显示为徽章，已弃用字段的名称会标红并划掉。
+- 其他属性显示为 `名称: 值` 徽章。
+
+### 嵌套
+
+字段可以嵌套以描述对象类型的字段。要在另一个字段内创建字段项目，每个嵌套级别将起始 `@` 增加一个。
+
+```md
+::: fields
+@options@ type="object"
+
+选项。
+
+@@options.name@ type="string"
+
+选项名称。
+
+@other@ type="string"
+
+其他字段。
+
+:::
+```
+
+更多语法细节，请参考 [@mdit/plugin-field](https://mdit-plugins.github.io/zh/field.html)。
+
+## 演示
+
+::: fields
+@theme@ type="ThemeConfig" required default="{ base: '/' }"
+
+主题配置
+
+@enabled@ type="boolean" optional default="true"
+
+是否启用
+
+@other@ type="string" deprecated
+
+已弃用字段
+
+:::
+
+## 选项
+
+### fields
+
+- 类型：`boolean`
+- 详情：是否启用字段容器。
+
+### locales
+
+- 类型：`MarkdownFieldPluginLocaleConfig`
+
+```ts
+interface MarkdownFieldPluginLocaleData {
+  /**
+   * `default` 属性的标签文本
+   */
+  default: string
+
+  /**
+   * `required` 属性的徽章文本
+   */
+  required: string
+
+  /**
+   * `optional` 属性的徽章文本
+   */
+  optional: string
+
+  /**
+   * `deprecated` 属性的徽章文本
+   */
+  deprecated: string
+}
+```
+
+- 详情：徽章文本的国际化配置。

--- a/plugins/markdown/plugin-markdown-field/package.json
+++ b/plugins/markdown/plugin-markdown-field/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@vuepress/plugin-markdown-field",
+  "version": "2.0.0-rc.134",
+  "description": "VuePress plugin - markdown field",
+  "keywords": [
+    "field",
+    "markdown",
+    "plugin",
+    "vuepress",
+    "vuepress-plugin"
+  ],
+  "homepage": "https://ecosystem.vuejs.press/plugins/markdown/markdown-field.html",
+  "bugs": {
+    "url": "https://github.com/vuepress/ecosystem/issues"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Mr.Hope",
+    "email": "mister-hope@outlook.com",
+    "url": "https://mister-hope.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vuepress/ecosystem.git",
+    "directory": "plugins/markdown/plugin-markdown-field"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "sideEffects": [
+    "./dist/**/*.css"
+  ],
+  "main": "./dist/node/index.js",
+  "types": "./dist/node/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/node/index.d.ts",
+      "default": "./dist/node/index.js"
+    },
+    "./field.css": "./dist/client/styles/field.css",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "clean": "rimraf ./dist"
+  },
+  "dependencies": {
+    "@mdit/helper": "^1.1.0",
+    "@mdit/plugin-field": "^2.0.1",
+    "@types/markdown-it": "^14.2.0",
+    "@vuepress/helper": "workspace:*"
+  },
+  "devDependencies": {
+    "markdown-it": "^14.3.1"
+  },
+  "peerDependencies": {
+    "vuepress": "catalog:"
+  }
+}

--- a/plugins/markdown/plugin-markdown-field/src/client/styles/field.scss
+++ b/plugins/markdown/plugin-markdown-field/src/client/styles/field.scss
@@ -1,0 +1,105 @@
+.vp-fields {
+  margin: 16px 0;
+  transition: border-color var(--vp-t-color);
+
+  .vp-field + .vp-field {
+    padding-top: 8px;
+    border-top: solid 1px var(--vp-c-divider);
+  }
+
+  .vp-field-header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+
+    margin: 8px 0;
+  }
+
+  .vp-field-name {
+    font-weight: 500;
+    font-size: 18px;
+  }
+
+  .vp-field.deprecated .vp-field-name {
+    color: var(--vp-c-red-text);
+    text-decoration: line-through;
+  }
+
+  .vp-field-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .vp-field-required,
+  .vp-field-optional,
+  .vp-field-deprecated,
+  .vp-field-attr {
+    display: inline-block;
+
+    padding: 2px 8px;
+    border-radius: 8px;
+
+    font-style: italic;
+    font-size: 12px;
+    line-height: 1;
+  }
+
+  .vp-field-required {
+    border: solid 1px var(--vp-c-green-text);
+    color: var(--vp-c-green-text);
+  }
+
+  .vp-field-optional,
+  .vp-field-attr {
+    border: solid 1px var(--vp-c-divider);
+    color: var(--vp-c-text-mute);
+  }
+
+  .vp-field-deprecated {
+    border: solid 1px var(--vp-c-red-text);
+    color: var(--vp-c-red-text);
+  }
+
+  .vp-field-type {
+    margin-inline-start: auto;
+    font-family: var(--code-font-family);
+    overflow-wrap: anywhere;
+  }
+
+  .vp-field-default {
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+
+    margin: 8px 0;
+
+    font-size: 14px;
+    line-height: 1.7;
+
+    code {
+      overflow-wrap: anywhere;
+    }
+  }
+
+  .vp-field-default-label {
+    flex-shrink: 0;
+    color: var(--vp-c-text-mute);
+  }
+
+  .vp-field-description {
+    :where(p, ul, ol) {
+      margin: 8px 0;
+      color: var(--vp-c-text-mute);
+      line-height: 24px;
+    }
+  }
+
+  dl {
+    margin: 8px 0;
+    padding-inline-start: 16px;
+    border-inline-start: solid 1px var(--vp-c-divider);
+  }
+}

--- a/plugins/markdown/plugin-markdown-field/src/node/field.ts
+++ b/plugins/markdown/plugin-markdown-field/src/node/field.ts
@@ -1,0 +1,94 @@
+import { escapeHtml } from '@mdit/helper'
+import { field as fieldPlugin } from '@mdit/plugin-field'
+import type {
+  MarkdownItFieldOpenRenderer,
+  MarkdownItFieldOptions,
+} from '@mdit/plugin-field'
+import { ensureLeadingSlash } from '@vuepress/helper'
+import type { PluginWithOptions } from 'markdown-it'
+import type { MarkdownEnv } from 'vuepress/markdown'
+import { resolveLocalePath } from 'vuepress/shared'
+
+import type {
+  MarkdownFieldPluginLocaleConfig,
+  MarkdownFieldPluginLocaleData,
+} from './options.js'
+
+const DEFAULT_LOCALE: MarkdownFieldPluginLocaleData = {
+  default: 'Default',
+  required: 'Required',
+  optional: 'Optional',
+  deprecated: 'Deprecated',
+}
+
+const escape = (value: string | true): string =>
+  value === true ? '' : escapeHtml(value)
+
+const resolveFieldLocale = (
+  options: MarkdownFieldPluginLocaleConfig,
+  env: MarkdownEnv,
+): MarkdownFieldPluginLocaleData => {
+  const relativePath = ensureLeadingSlash(env.filePathRelative ?? '')
+  const localePath = resolveLocalePath(options, relativePath)
+
+  return options[localePath] ?? DEFAULT_LOCALE
+}
+
+/**
+ * Field container markdown-it plugin
+ *
+ * 字段容器 markdown-it 插件
+ *
+ * @param md - MarkdownIt instance / MarkdownIt 实例
+ * @param options - Locale config / 国际化配置
+ */
+export const field: PluginWithOptions<MarkdownFieldPluginLocaleConfig> = (
+  md,
+  options = {},
+) => {
+  const fieldOpenRenderer: MarkdownItFieldOpenRenderer = (
+    { attributes, name },
+    tokens,
+    index,
+    _options,
+    env: MarkdownEnv,
+  ) => {
+    const locale = resolveFieldLocale(options, env)
+    const classNames = ['vp-field']
+    const badges: string[] = []
+    let type = ''
+    let defaultValue = ''
+
+    for (const { attr, value } of attributes) {
+      if (attr === 'type') {
+        type = `<code class="vp-field-type">${escape(value)}</code>\n`
+      } else if (attr === 'default') {
+        defaultValue = `<div class="vp-field-default">\n<span class="vp-field-default-label">${locale.default}</span>\n<code>${escape(value)}</code>\n</div>\n`
+      } else if (
+        attr === 'required' ||
+        attr === 'optional' ||
+        attr === 'deprecated'
+      ) {
+        if (attr === 'deprecated') classNames.push('deprecated')
+        badges.push(`<span class="vp-field-${attr}">${locale[attr]}</span>\n`)
+      } else {
+        badges.push(
+          `<span class="vp-field-attr">${attr}: ${escape(value)}</span>\n`,
+        )
+      }
+    }
+
+    const badgesHtml = badges.length
+      ? `<span class="vp-field-badges">\n${badges.join('')}</span>\n`
+      : ''
+
+    return `<div class="${classNames.join(' ')}">\n<div class="vp-field-header">\n<span class="vp-field-name">${escapeHtml(name)}</span>\n${badgesHtml}${type}</div>\n${defaultValue}<div class="vp-field-description">\n`
+  }
+
+  md.use<MarkdownItFieldOptions>(fieldPlugin, {
+    fieldsOpenRenderer: () => '<div class="vp-fields">\n',
+    fieldsCloseRenderer: () => '</div>\n',
+    fieldOpenRenderer,
+    fieldCloseRenderer: () => '</div>\n</div>\n',
+  })
+}

--- a/plugins/markdown/plugin-markdown-field/src/node/index.ts
+++ b/plugins/markdown/plugin-markdown-field/src/node/index.ts
@@ -1,0 +1,2 @@
+export * from './markdownFieldPlugin.js'
+export type * from './options.js'

--- a/plugins/markdown/plugin-markdown-field/src/node/locales.ts
+++ b/plugins/markdown/plugin-markdown-field/src/node/locales.ts
@@ -1,0 +1,187 @@
+import type { DefaultLocaleInfo } from '@vuepress/helper'
+
+import type { MarkdownFieldPluginLocaleData } from './options.js'
+
+export const fieldLocaleInfo: DefaultLocaleInfo<MarkdownFieldPluginLocaleData> =
+  [
+    [
+      ['en', 'en-US'],
+      {
+        default: 'Default',
+        required: 'Required',
+        optional: 'Optional',
+        deprecated: 'Deprecated',
+      },
+    ],
+    [
+      ['zh', 'zh-CN', 'zh-Hans'],
+      {
+        default: '默认值',
+        required: '必填',
+        optional: '可选',
+        deprecated: '已弃用',
+      },
+    ],
+    [
+      ['zh-TW', 'zh-Hant'],
+      {
+        default: '預設值',
+        required: '必填',
+        optional: '選填',
+        deprecated: '已棄用',
+      },
+    ],
+    [
+      ['de', 'de-DE'],
+      {
+        default: 'Standard',
+        required: 'Erforderlich',
+        optional: 'Optional',
+        deprecated: 'Veraltet',
+      },
+    ],
+    [
+      ['de-AT'],
+      {
+        default: 'Standard',
+        required: 'Erforderlich',
+        optional: 'Optional',
+        deprecated: 'Veraltet',
+      },
+    ],
+    [
+      ['vi', 'vi-VN'],
+      {
+        default: 'Mặc định',
+        required: 'Bắt buộc',
+        optional: 'Tùy chọn',
+        deprecated: 'Không dùng nữa',
+      },
+    ],
+    [
+      ['uk'],
+      {
+        default: 'За замовчуванням',
+        required: "Обов'язково",
+        optional: 'Необов’язково',
+        deprecated: 'Застаріло',
+      },
+    ],
+    [
+      ['ru', 'ru-RU'],
+      {
+        default: 'По умолчанию',
+        required: 'Обязательно',
+        optional: 'Необязательно',
+        deprecated: 'Устарело',
+      },
+    ],
+    [
+      ['br'],
+      {
+        default: 'Padrão',
+        required: 'Obrigatório',
+        optional: 'Opcional',
+        deprecated: 'Obsoleto',
+      },
+    ],
+    [
+      ['pl', 'pl-PL'],
+      {
+        default: 'Domyślne',
+        required: 'Wymagane',
+        optional: 'Opcjonalne',
+        deprecated: 'Przestarzałe',
+      },
+    ],
+    [
+      ['sk', 'sk-SK'],
+      {
+        default: 'Predvolené',
+        required: 'Povinné',
+        optional: 'Voliteľné',
+        deprecated: 'Zastarané',
+      },
+    ],
+    [
+      ['fr', 'fr-FR'],
+      {
+        default: 'Par défaut',
+        required: 'Requis',
+        optional: 'Optionnel',
+        deprecated: 'Obsolète',
+      },
+    ],
+    [
+      ['es', 'es-ES'],
+      {
+        default: 'Predeterminado',
+        required: 'Obligatorio',
+        optional: 'Opcional',
+        deprecated: 'Obsoleto',
+      },
+    ],
+    [
+      ['ja', 'ja-JP'],
+      {
+        default: 'デフォルト',
+        required: '必須',
+        optional: '任意',
+        deprecated: '非推奨',
+      },
+    ],
+    [
+      ['tr', 'tr-TR'],
+      {
+        default: 'Varsayılan',
+        required: 'Gerekli',
+        optional: 'İsteğe bağlı',
+        deprecated: 'Kullanımdan kaldırıldı',
+      },
+    ],
+    [
+      ['ko', 'ko-KO'],
+      {
+        default: '기본값',
+        required: '필수',
+        optional: '선택',
+        deprecated: '더 이상 사용되지 않음',
+      },
+    ],
+    [
+      ['fi', 'fi-FI'],
+      {
+        default: 'Oletus',
+        required: 'Pakollinen',
+        optional: 'Valinnainen',
+        deprecated: 'Vanhentunut',
+      },
+    ],
+    [
+      ['hu', 'hu-HU'],
+      {
+        default: 'Alapértelmezett',
+        required: 'Kötelező',
+        optional: 'Opcionális',
+        deprecated: 'Elavult',
+      },
+    ],
+    [
+      ['id', 'id-ID'],
+      {
+        default: 'Bawaan',
+        required: 'Wajib',
+        optional: 'Opsional',
+        deprecated: 'Usang',
+      },
+    ],
+    [
+      ['nl', 'nl-NL'],
+      {
+        default: 'Standaard',
+        required: 'Verplicht',
+        optional: 'Optioneel',
+        deprecated: 'Verouderd',
+      },
+    ],
+  ]

--- a/plugins/markdown/plugin-markdown-field/src/node/markdownFieldPlugin.ts
+++ b/plugins/markdown/plugin-markdown-field/src/node/markdownFieldPlugin.ts
@@ -1,0 +1,61 @@
+import { deepAssign, getFullLocaleConfig } from '@vuepress/helper'
+import type { Plugin } from 'vuepress/core'
+
+import { field } from './field.js'
+import { fieldLocaleInfo } from './locales.js'
+import type { MarkdownFieldPluginOptions } from './options.js'
+import { prepareClientConfigFile } from './prepareClientConfigFile.js'
+
+declare module 'vuepress/markdown' {
+  interface MarkdownOptions {
+    field?: MarkdownFieldPluginOptions
+  }
+}
+
+const PLUGIN_NAME = '@vuepress/plugin-markdown-field'
+
+/**
+ * Markdown field plugin
+ *
+ * Markdown 字段容器插件
+ *
+ * @example
+ *   import { markdownFieldPlugin } from '@vuepress/plugin-markdown-field'
+ *
+ *   export default {
+ *     plugins: [
+ *       markdownFieldPlugin({
+ *         fields: true,
+ *       }),
+ *     ],
+ *   }
+ */
+export const markdownFieldPlugin =
+  (options: MarkdownFieldPluginOptions): Plugin =>
+  (app) => {
+    const mergedOptions = deepAssign({}, app.options.markdown.field, options)
+    app.options.markdown.field = mergedOptions
+
+    if (!mergedOptions.fields) {
+      return {
+        name: PLUGIN_NAME,
+      }
+    }
+
+    const locale = getFullLocaleConfig({
+      app,
+      name: PLUGIN_NAME,
+      default: fieldLocaleInfo,
+      config: mergedOptions.locales,
+    })
+
+    return {
+      name: PLUGIN_NAME,
+
+      extendsMarkdown: (md) => {
+        md.use(field, locale)
+      },
+
+      clientConfigFile: () => prepareClientConfigFile(app, mergedOptions),
+    }
+  }

--- a/plugins/markdown/plugin-markdown-field/src/node/options.ts
+++ b/plugins/markdown/plugin-markdown-field/src/node/options.ts
@@ -1,0 +1,58 @@
+import type { ExactLocaleConfig } from '@vuepress/helper'
+import type { LocaleConfig } from 'vuepress/shared'
+
+export interface MarkdownFieldPluginLocaleData {
+  /**
+   * Label text for the `default` attribute
+   *
+   * `default` 属性的标签文本
+   */
+  default: string
+
+  /**
+   * Badge text for the `required` attribute
+   *
+   * `required` 属性的徽章文本
+   */
+  required: string
+
+  /**
+   * Badge text for the `optional` attribute
+   *
+   * `optional` 属性的徽章文本
+   */
+  optional: string
+
+  /**
+   * Badge text for the `deprecated` attribute
+   *
+   * `deprecated` 属性的徽章文本
+   */
+  deprecated: string
+}
+
+export type MarkdownFieldPluginLocaleConfig =
+  ExactLocaleConfig<MarkdownFieldPluginLocaleData>
+
+/**
+ * Markdown field plugin configuration
+ *
+ * Markdown 字段容器插件配置
+ */
+export interface MarkdownFieldPluginOptions {
+  /**
+   * Whether to enable fields
+   *
+   * 是否启用字段容器
+   *
+   * @default false
+   */
+  fields?: boolean
+
+  /**
+   * Locale config
+   *
+   * 国际化配置选项
+   */
+  locales?: LocaleConfig<MarkdownFieldPluginLocaleData>
+}

--- a/plugins/markdown/plugin-markdown-field/src/node/prepareClientConfigFile.ts
+++ b/plugins/markdown/plugin-markdown-field/src/node/prepareClientConfigFile.ts
@@ -1,0 +1,22 @@
+import { getModulePath } from '@vuepress/helper'
+import type { App } from 'vuepress'
+
+import type { MarkdownFieldPluginOptions } from './options.js'
+
+const PLUGIN_NAME = '@vuepress/plugin-markdown-field'
+
+export const prepareClientConfigFile = (
+  app: App,
+  { fields }: Pick<MarkdownFieldPluginOptions, 'fields'>,
+): Promise<string> => {
+  const imports = fields
+    ? `import "${getModulePath(`${PLUGIN_NAME}/field.css`, import.meta)}"\n`
+    : ''
+
+  return app.writeTemp(
+    'markdown-field/config.js',
+    `\
+${imports}
+`,
+  )
+}

--- a/plugins/markdown/plugin-markdown-field/tests/node/field.spec.ts
+++ b/plugins/markdown/plugin-markdown-field/tests/node/field.spec.ts
@@ -1,0 +1,155 @@
+import MarkdownIt from 'markdown-it'
+import { describe, expect, it } from 'vitest'
+
+import { field } from '../../src/node/field.js'
+
+const createMarkdownIt = (): MarkdownIt => new MarkdownIt().use(field)
+
+describe(field, () => {
+  it('should wrap fields with vp-field container', () => {
+    const markdownIt = createMarkdownIt()
+
+    expect(
+      markdownIt.render(`::: fields
+@theme@ type="ThemeConfig" required
+Theme Config
+:::
+`),
+    ).toBe(`<div class="vp-fields">
+<div class="vp-field">
+<div class="vp-field-header">
+<span class="vp-field-name">theme</span>
+<span class="vp-field-badges">
+<span class="vp-field-required">Required</span>
+</span>
+<code class="vp-field-type">ThemeConfig</code>
+</div>
+<div class="vp-field-description">
+<p>Theme Config</p>
+</div>
+</div>
+</div>
+`)
+  })
+
+  it('should render optional and default attributes', () => {
+    const markdownIt = createMarkdownIt()
+
+    expect(
+      markdownIt.render(`::: fields
+@enabled@ type="boolean" optional default="true"
+Whether it's enabled
+:::
+`),
+    ).toBe(`<div class="vp-fields">
+<div class="vp-field">
+<div class="vp-field-header">
+<span class="vp-field-name">enabled</span>
+<span class="vp-field-badges">
+<span class="vp-field-optional">Optional</span>
+</span>
+<code class="vp-field-type">boolean</code>
+</div>
+<div class="vp-field-default">
+<span class="vp-field-default-label">Default</span>
+<code>true</code>
+</div>
+<div class="vp-field-description">
+<p>Whether it's enabled</p>
+</div>
+</div>
+</div>
+`)
+  })
+
+  it('should mark deprecated fields', () => {
+    const markdownIt = createMarkdownIt()
+
+    const result = markdownIt.render(`::: fields
+@other@ type="string" deprecated
+Deprecated field
+:::
+`)
+
+    expect(result).toContain('class="vp-field deprecated"')
+    expect(result).toContain('class="vp-field-deprecated"')
+    expect(result).toContain('>Deprecated<')
+  })
+
+  it('should support nested fields', () => {
+    const markdownIt = createMarkdownIt()
+
+    const result = markdownIt.render(`::: fields
+@parent@ type="object"
+Parent description.
+@@parent.name@ type="string"
+Name description.
+:::
+`)
+
+    expect(result).toContain('<dl>')
+    expect(result).toContain('Parent description.')
+    expect(result).toContain('Name description.')
+  })
+
+  it('should escape field name and values', () => {
+    const markdownIt = createMarkdownIt()
+
+    expect(
+      markdownIt.render(`::: fields
+@a<b@ type="st&r"
+:::
+`),
+    ).toContain('&lt;b')
+    expect(
+      markdownIt.render(`::: fields
+@a<b@ type="st&r"
+:::
+`),
+    ).toContain('st&amp;r')
+  })
+
+  it('should use locale config for badges', () => {
+    const markdownIt = new MarkdownIt().use(field, {
+      '/': {
+        default: 'Default',
+        required: 'Required',
+        optional: 'Optional',
+        deprecated: 'Deprecated',
+      },
+      '/zh/': {
+        default: '默认值',
+        required: '必填',
+        optional: '可选',
+        deprecated: '已弃用',
+      },
+    })
+
+    const zhResult = markdownIt.render(
+      `::: fields
+@theme@ type="ThemeConfig" required default="{}"
+Theme Config
+
+@enabled@ type="boolean" optional
+Enabled
+:::
+`,
+      { filePathRelative: 'zh/foo.md' },
+    )
+
+    expect(zhResult).toContain('>必填<')
+    expect(zhResult).toContain('>可选<')
+    expect(zhResult).toContain('>默认值<')
+
+    const enResult = markdownIt.render(
+      `::: fields
+@theme@ type="ThemeConfig" required
+Theme Config
+:::
+`,
+      { filePathRelative: 'foo.md' },
+    )
+
+    expect(enResult).toContain('>Required<')
+  })
+})

--- a/plugins/markdown/plugin-markdown-field/tsdown.config.ts
+++ b/plugins/markdown/plugin-markdown-field/tsdown.config.ts
@@ -1,0 +1,6 @@
+import { tsdownConfig } from '../../../scripts/tsdown.ts'
+
+export default tsdownConfig([
+  'node/index',
+  { 'client/styles/*': './src/client/styles/*.scss' },
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       '@vuepress/plugin-markdown-ext':
         specifier: workspace:*
         version: link:../plugins/markdown/plugin-markdown-ext
+      '@vuepress/plugin-markdown-field':
+        specifier: workspace:*
+        version: link:../plugins/markdown/plugin-markdown-field
       '@vuepress/plugin-markdown-file-tree':
         specifier: workspace:*
         version: link:../plugins/markdown/plugin-markdown-file-tree
@@ -1001,6 +1004,28 @@ importers:
         specifier: ^14.3.1
         version: 14.3.1
 
+  plugins/markdown/plugin-markdown-field:
+    dependencies:
+      '@mdit/helper':
+        specifier: ^1.1.0
+        version: 1.1.1(markdown-it@14.3.1)
+      '@mdit/plugin-field':
+        specifier: ^2.0.1
+        version: 2.0.1(markdown-it@14.3.1)
+      '@types/markdown-it':
+        specifier: ^14.2.0
+        version: 14.2.0
+      '@vuepress/helper':
+        specifier: workspace:*
+        version: link:../../../tools/helper
+      vuepress:
+        specifier: 'catalog:'
+        version: 2.0.0-rc.31(636537a563f817181b911d10de04e73e)
+    devDependencies:
+      markdown-it:
+        specifier: ^14.3.1
+        version: 14.3.1
+
   plugins/markdown/plugin-markdown-file-tree:
     dependencies:
       '@types/markdown-it':
@@ -1122,7 +1147,7 @@ importers:
     dependencies:
       '@mdit/helper':
         specifier: ^1.1.0
-        version: 1.1.0(markdown-it@14.3.1)
+        version: 1.1.1(markdown-it@14.3.1)
       '@mdit/plugin-demo':
         specifier: ^2.0.0
         version: 2.0.0(markdown-it@14.3.1)
@@ -3173,6 +3198,15 @@ packages:
       markdown-it:
         optional: true
 
+  '@mdit/helper@1.1.1':
+    resolution: {integrity: sha512-Rrl14ZjFerzfAqCt0zxAWbPgRpsumgm9iBLrCVE05WS8dM6v/LnF1ppPFVnRz1F7fAaxn0kTFOlYwzcY+kRsHQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      markdown-it: ^15.0.1
+    peerDependenciesMeta:
+      markdown-it:
+        optional: true
+
   '@mdit/plugin-alert@2.0.0':
     resolution: {integrity: sha512-38dF7mUEGxeK/ez0FTU/FTUXpZNt5o9hhX1QSXZ8IkuBEA+Q7f0JUqX6tp1Ng8ecWVN2c95bGltSN1tar5R1mg==}
     engines: {node: '>=22'}
@@ -3214,6 +3248,15 @@ packages:
     engines: {node: '>=22'}
     peerDependencies:
       markdown-it: ^15.0.0
+    peerDependenciesMeta:
+      markdown-it:
+        optional: true
+
+  '@mdit/plugin-field@2.0.1':
+    resolution: {integrity: sha512-pu8KRS3K/a4o5tlACccnhhapVBhUY6J6RsBJOKqbtbCyR+SH1J4B6qH72w145EDf+zkRrAIdIiQRdoSqoKaxwg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      markdown-it: ^15.0.1
     peerDependenciesMeta:
       markdown-it:
         optional: true
@@ -11828,6 +11871,10 @@ snapshots:
     optionalDependencies:
       markdown-it: 14.3.1
 
+  '@mdit/helper@1.1.1(markdown-it@14.3.1)':
+    optionalDependencies:
+      markdown-it: 14.3.1
+
   '@mdit/plugin-alert@2.0.0(markdown-it@14.3.1)':
     dependencies:
       '@mdit/helper': 1.1.0(markdown-it@14.3.1)
@@ -11856,6 +11903,12 @@ snapshots:
   '@mdit/plugin-demo@2.0.0(markdown-it@14.3.1)':
     dependencies:
       '@mdit/helper': 1.1.0(markdown-it@14.3.1)
+    optionalDependencies:
+      markdown-it: 14.3.1
+
+  '@mdit/plugin-field@2.0.1(markdown-it@14.3.1)':
+    dependencies:
+      '@mdit/helper': 1.1.1(markdown-it@14.3.1)
     optionalDependencies:
       markdown-it: 14.3.1
 


### PR DESCRIPTION
## Summary

Close #602. Add `@vuepress/plugin-markdown-field` — a markdown field container plugin extracted from theme-plume with the adjusted `@name@` syntax.

It wraps [`@mdit/plugin-field`](https://mdit-plugins.github.io/field.html) and provides:

- `::: fields` container with `@name@ type="..." required default="..."` field items
- `type`, `default`, `required`, `optional`, `deprecated` attributes rendered as badges / code blocks
- Nested fields via increasing leading `@` (e.g. `@@name@`)
- i18n `locales` option for badge texts (20 languages, same set as other plugins)
- Styles reusing theme-default color variables, with narrow-screen (flex-wrap) support
- Docs (EN + ZH) and unit tests

## Changes

- `plugins/markdown/plugin-markdown-field` (new package)
- `docs/plugins/markdown/markdown-field.md`, `docs/zh/plugins/markdown/markdown-field.md`
- Docs site: enabled the plugin, added sidebar entries

## Checks

- `pnpm run type:check` ✅
- `pnpm run lint:check` ✅
- Unit tests: 6/6 ✅
- Docs build (SSR) ✅