### PR TITLE
fix(plugin-slimsearch): preserve inline whitespace in index

### DIFF
--- a/plugins/search/plugin-slimsearch/src/node/generateIndex.ts
+++ b/plugins/search/plugin-slimsearch/src/node/generateIndex.ts
@@ -100,8 +100,14 @@ export const generatePageIndex = (
 
   const addTextToIndex = (): void => {
     if (indexedText && shouldIndexContent) {
-      ;((foundFirstHeader ? sectionIndex! : pageIndex)[TEXT_INDEX_ID] ??=
-        []).push(indexedText.replaceAll(/[\n\s]+/gu, ' '))
+      // Trim the text and skip empty content, as whitespace-only text nodes are
+      // now preserved as word separators
+      const text = indexedText.replaceAll(/[\n\s]+/gu, ' ').trim()
+
+      if (text) {
+        ;((foundFirstHeader ? sectionIndex! : pageIndex)[TEXT_INDEX_ID] ??=
+          []).push(text)
+      }
       indexedText = ''
     }
   }
@@ -143,7 +149,15 @@ export const generatePageIndex = (
         })
       }
     } else if (node.type === 'text') {
-      indexedText += preserveSpace || node.data.trim() ? node.data : ''
+      // Whitespace-only text nodes between inline elements are preserved as a
+      // single space, so that adjacent inline elements (e.g. `<span>a</span>
+      // <span>b</span>`) are indexed as separate words instead of being joined.
+      // `preserveSpace` contexts (e.g. `<pre>`) keep the original whitespace.
+      indexedText += node.data.trim()
+        ? node.data
+        : preserveSpace
+          ? node.data
+          : ' '
     } else if (
       // We are expecting to stop at excerpt marker if content is not indexed
       hasExcerpt &&

--- a/plugins/search/plugin-slimsearch/tests/__snapshots__/generateIndex.spec.ts.snap
+++ b/plugins/search/plugin-slimsearch/tests/__snapshots__/generateIndex.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`generatePageIndex > should generate full index 1`] = `
     "id": "0",
     "t": [
       "Text 1.",
-      "Text 2 with , , , and ., , , and .",
+      "Text 2 with , , , and . , , , and .",
       "Text 11 with , , , and .",
     ],
   },
@@ -21,7 +21,7 @@ exports[`generatePageIndex > should generate full index 2`] = `
     "id": "1",
     "t": [
       "Here is article excerpt.",
-      "const a = 1 ",
+      "const a = 1",
     ],
   },
   {
@@ -32,7 +32,7 @@ exports[`generatePageIndex > should generate full index 2`] = `
       "A",
       "B",
       "C",
-      "const a = 1 ",
+      "const a = 1",
     ],
   },
   {
@@ -115,7 +115,7 @@ exports[`generatePageIndex > should generate full index 3`] = `
     "t": [
       "Create a list by starting a line with -",
       "Make sub-lists by indenting 2 spaces:",
-      "Marker character change forces new list start: ",
+      "Marker character change forces new list start:",
       "Ac tristique libero volutpat at",
       "Facilisis in pretium nisl aliquet",
       "Nulla volutpat aliquam velit link break",
@@ -180,9 +180,9 @@ exports[`generatePageIndex > should generate full index 3`] = `
     "t": [
       "Inline Code: code",
       "Block code:",
-      "Sample text here... ",
+      "Sample text here...",
       "Syntax highlighting:",
-      "function foo(bar) { return \`foo\${bar}\` } console.log(foo(5)) ",
+      "function foo(bar) { return \`foo\${bar}\` } console.log(foo(5))",
     ],
   },
 ]
@@ -496,14 +496,14 @@ exports[`generatePageIndex > should preserve content inside custom tags with pre
     "t": [
       "Human readable content",
       "Human readable content",
-      "Inline , , ",
-      "Human readable content, and ",
+      "Inline , ,",
+      "Human readable content, and",
       "Human readable content mixed together.",
       "Normal content",
-      "Some badges: ",
+      "Some badges:",
       "text1",
       "text2.",
-      "Some other tags: ",
+      "Some other tags:",
       "text3",
       "text4.",
     ],
@@ -518,7 +518,7 @@ exports[`generatePageIndex > should remove custom tags by default > default 1`] 
     "id": "0",
     "t": [
       "Text 1.",
-      "Text 2 with , , , and ., , , and .",
+      "Text 2 with , , , and . , , , and .",
       "Text 11 with , , , and .",
     ],
   },
@@ -705,7 +705,7 @@ exports[`generatePageIndex > should support customFields with full index 1`] = `
     "id": "0",
     "t": [
       "Text 1.",
-      "Text 2 with , , , and ., , , and .",
+      "Text 2 with , , , and . , , , and .",
       "Text 11 with , , , and .",
     ],
   },
@@ -719,7 +719,7 @@ exports[`generatePageIndex > should support customFields with full index 2`] = `
     "id": "1",
     "t": [
       "Here is article excerpt.",
-      "const a = 1 ",
+      "const a = 1",
     ],
   },
   {
@@ -730,7 +730,7 @@ exports[`generatePageIndex > should support customFields with full index 2`] = `
       "A",
       "B",
       "C",
-      "const a = 1 ",
+      "const a = 1",
     ],
   },
   {
@@ -819,7 +819,7 @@ exports[`generatePageIndex > should support customFields with full index 3`] = `
     "t": [
       "Create a list by starting a line with -",
       "Make sub-lists by indenting 2 spaces:",
-      "Marker character change forces new list start: ",
+      "Marker character change forces new list start:",
       "Ac tristique libero volutpat at",
       "Facilisis in pretium nisl aliquet",
       "Nulla volutpat aliquam velit link break",
@@ -884,9 +884,9 @@ exports[`generatePageIndex > should support customFields with full index 3`] = `
     "t": [
       "Inline Code: code",
       "Block code:",
-      "Sample text here... ",
+      "Sample text here...",
       "Syntax highlighting:",
-      "function foo(bar) { return \`foo\${bar}\` } console.log(foo(5)) ",
+      "function foo(bar) { return \`foo\${bar}\` } console.log(foo(5))",
     ],
   },
 ]

--- a/plugins/search/plugin-slimsearch/tests/inlineWhitespace.spec.ts
+++ b/plugins/search/plugin-slimsearch/tests/inlineWhitespace.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import type { Page } from 'vuepress/core'
+
+import { generatePageIndex } from '../src/node/generateIndex.js'
+import type { PageIndexItem } from '../src/node/index.js'
+import { PathStore } from '../src/node/pathStore.js'
+
+const makePage = (contentRendered: string): Page =>
+  ({
+    path: '/test.html',
+    pathLocale: '/',
+    title: 'Test',
+    contentRendered,
+    frontmatter: {},
+    data: {},
+  }) as Page
+
+describe('inline element whitespace handling', () => {
+  it('vp-fields style HTML (newlines between spans) is split into separate words', () => {
+    const html = `<div class="vp-field">
+<div class="vp-field-header">
+<span class="vp-field-name">theme</span>
+<span class="vp-field-badges">
+<span class="vp-field-required">Required</span>
+</span>
+<code class="vp-field-type">ThemeConfig</code></div>
+<div class="vp-field-description">
+<p>Theme Config</p>
+</div>
+</div>`
+
+    const store = new PathStore()
+    const items = generatePageIndex(makePage(html), store, {
+      indexContent: true,
+    })
+    const text = JSON.stringify(items)
+
+    expect(text).toContain('theme')
+    expect(text).toContain('Required')
+    expect(text).toContain('ThemeConfig')
+    // must NOT be joined into one long word
+    expect(text).not.toContain('themeRequiredThemeConfig')
+  })
+
+  it('compact spans without whitespace are joined into a single word', () => {
+    const html =
+      '<div><span>Hello</span><span>World</span><span>foo</span></div>'
+
+    const store = new PathStore()
+    const items = generatePageIndex(makePage(html), store, {
+      indexContent: true,
+    })
+    const joined = (items[0] as PageIndexItem).t!.join(' ')
+
+    // No whitespace between inline elements → joined
+    expect(joined).toBe('HelloWorldfoo')
+  })
+
+  it('a word split across spans is correctly re-joined', () => {
+    const html = '<div><span>Hel</span><span>lo</span> world</div>'
+
+    const store = new PathStore()
+    const items = generatePageIndex(makePage(html), store, {
+      indexContent: true,
+    })
+    const joined = (items[0] as PageIndexItem).t!.join(' ')
+
+    expect(joined).toBe('Hello world')
+  })
+})


### PR DESCRIPTION
### Description

Fixes the indexer concatenating text across adjacent inline elements (e.g. `<span>a</span><span>b</span>`) into a single long word.

### Root cause

Whitespace-only text nodes between inline elements were discarded:

```ts
indexedText += preserveSpace || node.data.trim() ? node.data : ''
```

So the whitespace acting as a word separator between inline elements was lost. For example, this DOM:

```html
<span class="vp-field-name">theme</span>
<span class="vp-field-required">Required</span>
```

was indexed as `themeRequired`, and could appear as a single long word in search results/suggestions.

### Fix

- Whitespace-only text nodes are now preserved as a single space, so inline elements separated by whitespace are indexed as separate words, while elements with no whitespace between them (e.g. a word split across spans) are still joined.
- Indexed text is trimmed and empty entries are skipped.

### Tests

- Added `tests/inlineWhitespace.spec.ts` covering: whitespace-separated spans split correctly, compact spans without whitespace stay joined, and split words are re-joined.
- Updated `generateIndex` snapshots (whitespace now preserved / trailing whitespace trimmed).

Note: the identical fix is applied to `@vuepress/plugin-orama` in PR #841.