### PR TITLE
feat(plugin-markdown-chart): support mermaid v12

### DIFF
--- a/docs/plugins/markdown/markdown-chart/mermaid.md
+++ b/docs/plugins/markdown/markdown-chart/mermaid.md
@@ -63,6 +63,7 @@ export default {
 
 Besides using mermaid, you can also use the following code blocks:
 
+- block: `block`
 - class: `classDiagram`
 - c4c: `C4Context`
 - er: `erDiagram`
@@ -71,19 +72,24 @@ Besides using mermaid, you can also use the following code blocks:
 - journey: `journey`
 - mindmap: `mindmap`
 - kanban: `kanban`
+- packet: `packet`
 - pie: `pie`
 - quadrant: `quadrantChart`
 - requirement: `requirementDiagram`
+- sankey: `sankey`
 - sequence: `sequenceDiagram`
 - state: `stateDiagram-v2`
 - timeline: `timeline`
+- agentflow: `agentflow-beta`
 - architecture: `architecture-beta`
-- block: `block-beta`
-- packet: `packet-beta`
+- ishikawa: `ishikawa-beta`
 - radar: `radar-beta`
-- sankey: `sankey-beta`
 - treemap: `treemap-beta`
-- xy: `xychart-beta`
+- treeview: `treeView-beta`
+- usecase: `usecase-beta`
+- venn: `venn-beta`
+- wardley: `wardley-beta`
+- xy: `xychart`
 
 You do not need to declare diagram type and intent your code.
 
@@ -575,6 +581,39 @@ axis A, B, C, D, E
 curve c1{1,2,3,4,5}
 curve c2{5,4,3,2,1}
 curve c3{3,3,3,3,3}
+```
+
+:::
+
+::: preview Use Case Diagram
+
+```usecase
+direction LR
+actor Customer("Customer")
+actor Support("Support agent")
+systemBoundary Ordering["Ordering system"]
+  Browse("Browse products")
+  Checkout("Checkout")
+  Payment("Process payment")
+end
+Customer --> Browse
+Customer --> Checkout
+Support --> Checkout
+Checkout ..> : include Payment
+```
+
+:::
+
+::: preview Agentflow Diagram
+
+```agentflow
+flow reviewer["Review Agent"]
+  changes["Gather changes"]@{ shape: input }
+  analyse["Analyse diff"]@{ shape: task }
+  lint["run_linter"]@{ shape: tool }
+  ok["Clean?"]@{ shape: decision }
+  changes --> analyse --> lint --> ok
+end
 ```
 
 :::

--- a/docs/zh/plugins/markdown/markdown-chart/mermaid.md
+++ b/docs/zh/plugins/markdown/markdown-chart/mermaid.md
@@ -65,6 +65,7 @@ export default {
 
 除了使用 mermaid 代码块，你也可以直接使用以下代码块：
 
+- block: `block`
 - class: `classDiagram`
 - c4c: `C4Context`
 - er: `erDiagram`
@@ -73,19 +74,24 @@ export default {
 - journey: `journey`
 - mindmap: `mindmap`
 - kanban: `kanban`
+- packet: `packet`
 - pie: `pie`
 - quadrant: `quadrantChart`
 - requirement: `requirementDiagram`
+- sankey: `sankey`
 - sequence: `sequenceDiagram`
 - state: `stateDiagram-v2`
 - timeline: `timeline`
+- agentflow: `agentflow-beta`
 - architecture: `architecture-beta`
-- block: `block-beta`
-- packet: `packet-beta`
+- ishikawa: `ishikawa-beta`
 - radar: `radar-beta`
-- sankey: `sankey-beta`
 - treemap: `treemap-beta`
-- xy: `xychart-beta`
+- treeview: `treeView-beta`
+- usecase: `usecase-beta`
+- venn: `venn-beta`
+- wardley: `wardley-beta`
+- xy: `xychart`
 
 你不需要再声明图表类型，也不需要缩进图表代码。
 
@@ -577,6 +583,39 @@ axis A, B, C, D, E
 curve c1{1,2,3,4,5}
 curve c2{5,4,3,2,1}
 curve c3{3,3,3,3,3}
+```
+
+:::
+
+::: preview 用例图
+
+```usecase
+direction LR
+actor Customer("Customer")
+actor Support("Support agent")
+systemBoundary Ordering["Ordering system"]
+  Browse("Browse products")
+  Checkout("Checkout")
+  Payment("Process payment")
+end
+Customer --> Browse
+Customer --> Checkout
+Support --> Checkout
+Checkout ..> : include Payment
+```
+
+:::
+
+::: preview 智能体流程图
+
+```agentflow
+flow reviewer["Review Agent"]
+  changes["Gather changes"]@{ shape: input }
+  analyse["Analyse diff"]@{ shape: task }
+  lint["run_linter"]@{ shape: tool }
+  ok["Clean?"]@{ shape: decision }
+  changes --> analyse --> lint --> ok
+end
 ```
 
 :::

--- a/plugins/markdown/plugin-markdown-chart/package.json
+++ b/plugins/markdown/plugin-markdown-chart/package.json
@@ -74,7 +74,7 @@
     "markmap-lib": "^0.18.12",
     "markmap-toolbar": "^0.18.12",
     "markmap-view": "^0.18.12",
-    "mermaid": "^11.14.0",
+    "mermaid": "^12.0.0",
     "vuepress": "catalog:"
   },
   "peerDependenciesMeta": {

--- a/plugins/markdown/plugin-markdown-chart/src/client/components/Mermaid.ts
+++ b/plugins/markdown/plugin-markdown-chart/src/client/components/Mermaid.ts
@@ -60,7 +60,7 @@ export default defineComponent({
       if (__VUEPRESS_SSR__) return
 
       const { default: mermaid } = await import(
-        /* webpackChunkName: "mermaid" */ 'mermaid/dist/mermaid.esm.min.mjs'
+        /* webpackChunkName: "mermaid" */ 'mermaid'
       )
 
       mermaid.initialize({

--- a/plugins/markdown/plugin-markdown-chart/src/node/markdown-it-plugins/mermaid.ts
+++ b/plugins/markdown/plugin-markdown-chart/src/node/markdown-it-plugins/mermaid.ts
@@ -95,11 +95,13 @@ const DIAGRAM_MAP: Record<string, [diagramName: string, indent?: boolean]> = {
   'timeline': [''],
 
   // beta diagrams
+  'agentflow': ['agentflow-beta'],
   'architecture': ['architecture-beta'],
   'ishikawa': ['ishikawa-beta'],
   'radar': ['radar-beta'],
   'treemap': ['treemap-beta', false],
   'treeview': ['treeView-beta'],
+  'usecase': ['usecase-beta'],
   'venn': ['venn-beta', false],
   'wardley': ['wardley-beta', false],
   'xy': ['xychart', false],

--- a/plugins/markdown/plugin-markdown-chart/tests/node/__snapshots__/mermaid.spec.ts.snap
+++ b/plugins/markdown/plugin-markdown-chart/tests/node/__snapshots__/mermaid.spec.ts.snap
@@ -103,6 +103,8 @@ exports[`mermaid plugin > should not render > wrong fence 1`] = `
 "
 `;
 
+exports[`mermaid plugin > should render \`\`\`agentflow 1`] = `"<Mermaid code="eJxNjLEOwjAMRPd+xcl7foAB0YmdNepgqNNEVKZKDBVC/DttaaVuz753x52ohf4xuqsYV8DMyPJKMkr2dFkI9axRM+XALbJ2Ujyd2aLk7abm9EGJPMgBSYen4bvorNy/i3iq/4A2hbCXjct9ddcpOHfcetNftK1+9Aw3oQ=="></Mermaid>"`;
+
 exports[`mermaid plugin > should render \`\`\`class 1`] = `"<Mermaid code="eJxdjTEOwjAMRfecwiMV4gLMjCAh9QQWRMESTUpsJoTPjutGbcUSxf8/+92eyHwiTBWHAOAj9K831qj9A8eoH4sBKAvQ3b9nYlGbFcbCJFSyxxzlWizm3RaYgs77tPTdesKab7BnNsIRDl6xVMpJYYjMmCJvib2JLi2fVf/05Ftx8y54M7eF8APCy1cA"></Mermaid>"`;
 
 exports[`mermaid plugin > should render \`\`\`er 1`] = `"<Mermaid code="eJx1jT0OwjAMhfeewhfIBdgqkoGBgILEboSJLPIjOUEMbe9OKnVoBgbLz89P7yPRjF4wDgDH0cE8K5UnsOPZaKXd6W4cHABDyN+yRaa2AUoVTh6EPDeJlXOyn/gg2X8jvqm785NCM5Y2V+NuF/sHyCtsS3S8F0upFmNXG3DncaqAftXL8ANM5kJr"></Mermaid>"`;
@@ -122,3 +124,5 @@ exports[`mermaid plugin > should render \`\`\`sequence > with title 1`] = `"<Mer
 exports[`mermaid plugin > should render \`\`\`sequence > without title 1`] = `"<Mermaid code="eJxtkL2OwjAQhHueYq4nuR6dcuKnAAp6SicssUXiFfZGCW/POgSQEN1q5tvZn0jXjnxFG2fqYNoZsGxcRciKAisuF9hS03Aq57DcwwTCjbt/BVXLFNuz9Yolr+ROkoukvZDhEbnADqZFzXyCWOMv8WcihpH/7h9YCMHVVsDnidMeJZwSMGjY139l+C1SAXEtzRH5LWuUKE0QGgQnpjjKngVnp6FeMwL3+ex10bTt2lJ1cZrZO7Hj5DzPn//JprOPFFUd3Y//3AGRcm49"></Mermaid>"`;
 
 exports[`mermaid plugin > should render \`\`\`state 1`] = `"<Mermaid code="eJwrLkksSXXJTEwvSszVLTPiUlCI1opV0NW1U3BMLsksS+UCioDVQPkK1UABhCK/0lyf/ORs/7Q0sDCCiyKbp2Cl4FoG5QUUpRYXp6agqM9DMwyXel1dFNudEwuKka1H4qPKQxwA4yKbiKQEzUScWtAcEZxclJ+Tg+wMFBF0NRCnIASQTUZRhmE2To21XAApZ4wz"></Mermaid>"`;
+
+exports[`mermaid plugin > should render \`\`\`usecase 1`] = `"<Mermaid code="eJxdTTsOwjAM3TnFUyYY2gMwdGhXJCRWxBASCyJogmxHqLcnlGRhsZ/9flnIWaHuSmo3gA9MTkOKOJzKaZ0mxpRF00y8NQ2ZXSFlEaV5TDl6ywuO7IlDvJ1NQ1VhLkUMjJzeQlvz23hx8tmprFHAdCf3SFlLR0UrQdGX2WrRdUPN+f821/dfIfp+wB4humf21HwfTBdPJw=="></Mermaid>"`;

--- a/plugins/markdown/plugin-markdown-chart/tests/node/mermaid.spec.ts
+++ b/plugins/markdown/plugin-markdown-chart/tests/node/mermaid.spec.ts
@@ -272,4 +272,36 @@ commit
 
     expect(renderResult).toMatchSnapshot()
   })
+
+  it('should render ```usecase', () => {
+    const renderResult = markdownIt.render(`
+\`\`\`usecase
+direction LR
+actor Customer("Customer")
+systemBoundary Ordering["Ordering system"]
+  Browse("Browse products")
+  Checkout("Checkout")
+end
+Customer --> Browse
+Customer --> Checkout
+Checkout ..> : include Browse
+\`\`\`
+`)
+
+    expect(renderResult).toMatchSnapshot()
+  })
+
+  it('should render ```agentflow', () => {
+    const renderResult = markdownIt.render(`
+\`\`\`agentflow
+flow reviewer["Review Agent"]
+  changes["Gather changes"]@{ shape: input }
+  analyse["Analyse diff"]@{ shape: task }
+  changes --> analyse
+end
+\`\`\`
+`)
+
+    expect(renderResult).toMatchSnapshot()
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -935,8 +935,8 @@ importers:
         specifier: ^0.18.12
         version: 0.18.12(markmap-common@0.18.9)
       mermaid:
-        specifier: ^11.14.0
-        version: 11.17.2
+        specifier: ^12.0.0
+        version: 12.0.0
       vue:
         specifier: 'catalog:'
         version: 3.5.42(typescript@6.0.3)
@@ -2516,8 +2516,20 @@ packages:
   '@cacheable/utils@2.5.0':
     resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
 
+  '@chevrotain/cst-dts-gen@11.1.2':
+    resolution: {integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==}
+
+  '@chevrotain/gast@11.1.2':
+    resolution: {integrity: sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==}
+
+  '@chevrotain/regexp-to-ast@11.1.2':
+    resolution: {integrity: sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==}
+
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@chevrotain/utils@11.1.2':
+    resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
 
   '@colordx/core@5.8.0':
     resolution: {integrity: sha512-cG0QJAO6VkaRUlIb0zOzX9gfJgs1pjoOL9gZ/PK1kfvBs0GCkADu5oQh6gPxXgQnZ3gV575h+lQRC0NlMDTclA==}
@@ -3477,8 +3489,9 @@ packages:
       markdown-it:
         optional: true
 
-  '@mermaid-js/parser@1.2.1':
-    resolution: {integrity: sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==}
+  '@mermaid-js/parser@2.0.0':
+    resolution: {integrity: sha512-K8BeapFUfrfxbRAUQAG5oBOCwo1+bNWzaVnPxTCutkfrTBn6T/j91FIhqxWJ32SUeQ9T3iy1zcmPZ5ROZEvDrg==}
+    engines: {node: '>=22.12.0'}
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
@@ -5442,6 +5455,9 @@ packages:
     resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
     engines: {node: '>=20.18.1'}
 
+  chevrotain@11.1.2:
+    resolution: {integrity: sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==}
+
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
@@ -6144,6 +6160,9 @@ packages:
   electron-to-chromium@1.5.423:
     resolution: {integrity: sha512-rRZfTSY8ptHYMQxa+uIycJMFKmY1T0GIApNMXJYGehguTZa56TEEl19pKPCoBqk5Gpf7QizZn/jt7xur+DYxag==}
 
+  elkjs@0.9.3:
+    resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -6337,9 +6356,6 @@ packages:
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
-
-  fastdom@1.0.12:
-    resolution: {integrity: sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -7304,6 +7320,9 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  lodash-es@4.17.23:
+    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
@@ -7521,8 +7540,9 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.17.2:
-    resolution: {integrity: sha512-V6K3C8EBdEsPFZXSKMJe6ppQOENxuHARr9GvHX4hh47lAbhMRD9qf4oEK7LoaRQxULMa80/qt5gHO73aCleBBg==}
+  mermaid@12.0.0:
+    resolution: {integrity: sha512-/wQXC9iBxoGV8p3erbvaXs9h77VyLDBH6GdayVjj3hEcSQhFU4N1WUhUppotCEqlIxI2pRMwjwBSwTB1MfZBgQ==}
+    engines: {node: '>=22.12.0'}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -9255,9 +9275,6 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
-
-  strictdom@1.0.1:
-    resolution: {integrity: sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -11226,7 +11243,22 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
+  '@chevrotain/cst-dts-gen@11.1.2':
+    dependencies:
+      '@chevrotain/gast': 11.1.2
+      '@chevrotain/types': 11.1.2
+      lodash-es: 4.17.23
+
+  '@chevrotain/gast@11.1.2':
+    dependencies:
+      '@chevrotain/types': 11.1.2
+      lodash-es: 4.17.23
+
+  '@chevrotain/regexp-to-ast@11.1.2': {}
+
   '@chevrotain/types@11.1.2': {}
+
+  '@chevrotain/utils@11.1.2': {}
 
   '@colordx/core@5.8.0': {}
 
@@ -12057,7 +12089,7 @@ snapshots:
     optionalDependencies:
       markdown-it: 14.3.1
 
-  '@mermaid-js/parser@1.2.1':
+  '@mermaid-js/parser@2.0.0':
     dependencies:
       '@chevrotain/types': 11.1.2
 
@@ -14167,6 +14199,15 @@ snapshots:
       undici: 7.29.1
       whatwg-mimetype: 4.0.0
 
+  chevrotain@11.1.2:
+    dependencies:
+      '@chevrotain/cst-dts-gen': 11.1.2
+      '@chevrotain/gast': 11.1.2
+      '@chevrotain/regexp-to-ast': 11.1.2
+      '@chevrotain/types': 11.1.2
+      '@chevrotain/utils': 11.1.2
+      lodash-es: 4.17.23
+
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -14917,6 +14958,8 @@ snapshots:
 
   electron-to-chromium@1.5.423: {}
 
+  elkjs@0.9.3: {}
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -15195,10 +15238,6 @@ snapshots:
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
-
-  fastdom@1.0.12:
-    dependencies:
-      strictdom: 1.0.1
 
   fastest-levenshtein@1.0.16: {}
 
@@ -16161,6 +16200,8 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lodash-es@4.17.23: {}
+
   lodash-es@4.18.1: {}
 
   lodash.debounce@4.0.8: {}
@@ -16471,13 +16512,14 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.17.2:
+  mermaid@12.0.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.7
-      '@mermaid-js/parser': 1.2.1
+      '@mermaid-js/parser': 2.0.0
       '@types/d3': 7.4.3
       '@upsetjs/venn.js': 2.0.0
+      chevrotain: 11.1.2
       cytoscape: 3.34.3
       cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.3)
       cytoscape-fcose: 2.2.0(cytoscape@3.34.3)
@@ -16486,8 +16528,8 @@ snapshots:
       dagre-d3-es: 7.0.14
       dayjs: 1.11.23
       dompurify: 3.4.15
+      elkjs: 0.9.3
       es-toolkit: 1.52.0
-      fastdom: 1.0.12
       katex: 0.16.47
       khroma: 2.1.0
       marked: 16.4.2
@@ -18343,8 +18385,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
-
-  strictdom@1.0.1: {}
 
   string-width@4.2.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,6 +36,8 @@ minimumReleaseAgeExclude:
   - vue
   - vuepress
   - stylelint-config-hope@12.1.0
+  - '@mermaid-js/parser@2.0.0'
+  - mermaid@12.0.0
 
 packageExtensions:
   stylelint:


### PR DESCRIPTION
### Features

- Bump `mermaid` peer dependency to `^12.0.0`
- Import mermaid by package name, since mermaid 12 no longer expects the internal `dist/mermaid.esm.min.mjs` entry
- Support `usecase` (`usecase-beta`) and `agentflow` (`agentflow-beta`) diagrams added in mermaid 12
- Complete the fence info list in docs and add demos for the two new diagrams

### Breaking changes of mermaid 12

Mermaid 12 is now built for ES2024 / Safari 17.4+, bundles ELK and uses it as the default layout, and switches 10 diagram types to the `redux-color` theme and the `neo` look by default. Users who prefer the previous appearance can set `theme: 'default'`, `look: 'classic'` and `layout: 'dagre'` through `defineMermaidConfig`.